### PR TITLE
build: one way to build the xclbins, and one contract between the pro…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,23 @@ Note: Peano (llvm-aie) has not been added to PATH to avoid conflict with
 
 Activate the ironvenv/bin/activate; use source utilities/mlir-aie/utils/env_setup.sh also *if needed*
 
+## Building xclbins
+
+The xclbins are built, not checked in. There is ONE command for every design set
+in the repository, and one document describing the convention:
+
+    python tools/build_designs.py doctor   # can this shell build at all?
+    python tools/build_designs.py list     # what exists, and is it built?
+    python tools/build_designs.py build    # build what is missing
+    python tools/build_designs.py check    # do the built sets match their spec?
+
+Read `docs/design-sets.md` before adding a third producer. The short version:
+`ironvenv-requirements.txt` is the only toolchain pin, `tools/npu_designs.py`
+holds everything two producers must agree about (the `toolchain.json` schema,
+the shared `~/.npu/cache` lock, the device pin, the xclbin comparison), and each
+producer's flags stay in its own spec — `npu_offload/gemm_rtp/families.json` and
+`open_kernels/export_qwen36_kernels.py`'s `SETS`. Nothing restates them.
+
 <available_skills>
   <skill>
     <name>npu_offload_pipeline</name>

--- a/build_executable.bat
+++ b/build_executable.bat
@@ -1,0 +1,49 @@
+@echo off
+setlocal
+::
+:: Build flm.exe on Windows.
+::
+::     build_executable.bat              configure + build via vcpkg + MSVC
+::     build_executable.bat <vcpkg-root> use a vcpkg other than C:\dev\vcpkg
+::
+:: THE CONTRACT IS THE SAME AS build_executable.sh; THE INSIDE IS NOT, AND
+:: PRETENDING OTHERWISE WOULD BE A LIE. Same name, same place, same output --
+:: but this leg is MSVC plus a vcpkg toolchain, and the Linux leg is CMake plus
+:: the system compiler. They cannot be one script, because this build cannot
+:: run there: XRT's Windows import library exports 2,395 MSVC-mangled C++
+:: symbols with std::string in the signatures, the NPU path (hw_context,
+:: ext::bo, elf, module) has ZERO plain-C entry points, and hrx.dll is a closed
+:: prebuilt nobody can rebuild.
+::
+:: The xclbins are the opposite case and DO build identically everywhere:
+:: build_xclbin.bat, one implementation, both hosts.
+::
+:: This forwards to src\build-windows-vcpkg.cmd, which is the path that worked
+:: on a bare box: no standalone Boost b2 build, no hand-copied import libs.
+:: One-time setup is documented in that file's header. If a configure has
+:: already failed once in this tree, use clean_build.bat instead -- CMake does
+:: NOT re-apply a toolchain file to an existing cache, so a half-configured
+:: build directory silently links a different Boost forever.
+
+if /I "%~1"=="--help" goto :usage
+if /I "%~1"=="-h"     goto :usage
+
+where cl >nul 2>&1
+if errorlevel 1 (
+    echo No 'cl' on this shell's path -- this needs the MSVC environment.
+    echo Open "x64 Native Tools Command Prompt for VS" and re-run.
+    echo A script that re-derives that environment is liability, not convenience.
+    exit /b 1
+)
+
+call "%~dp0src\build-windows-vcpkg.cmd" %*
+exit /b %ERRORLEVEL%
+
+:usage
+echo Build flm.exe on Windows (MSVC + vcpkg).
+echo.
+echo     build_executable.bat              configure + build
+echo     build_executable.bat ^<vcpkg-root^> use a vcpkg other than C:\dev\vcpkg
+echo.
+echo For the NPU design sets instead: build_xclbin.bat
+exit /b 0

--- a/build_executable.sh
+++ b/build_executable.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env sh
+# Build the flm executable on Linux.
+#
+#   ./build_executable.sh                 configure + build (preset linux-default)
+#   ./build_executable.sh --preset linux-portable
+#   ./build_executable.sh --install       then install into ~/flm_exe, no sudo
+#
+# THE CONTRACT IS THE SAME AS build_executable.bat; THE INSIDE IS NOT, AND
+# PRETENDING OTHERWISE WOULD BE A LIE. Same name, same place, same flags, same
+# output directory -- but this leg is CMake + your system compiler, and the
+# Windows leg is MSVC plus a vcpkg toolchain and a WiX installer. They cannot
+# be one script, because the Windows build cannot run here:
+#
+#   * XRT's Windows import library exports 2,395 MSVC-MANGLED C++ symbols with
+#     std::string in the signatures. The NPU path is C++-only -- hw_context,
+#     ext::bo, elf and module have ZERO plain-C entry points -- so mingw cannot
+#     link it at all. clang-cl could (it keeps the MSVC ABI), but it needs the
+#     Windows SDK and MSVC CRT, which are Microsoft's to redistribute, not ours.
+#   * hrx.dll is fetched as a closed prebuilt binary. Nobody can rebuild it.
+#
+# The xclbins are the opposite case and DO build identically everywhere:
+# ./build_xclbin.sh, one implementation, both hosts.
+set -eu
+
+here=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+preset=linux-default
+install=0
+args=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --preset) preset=$2; shift 2 ;;
+        --install) install=1; shift ;;
+        -h|--help) sed -n '2,10p' "$0"; exit 0 ;;
+        *) args="$args $1"; shift ;;
+    esac
+done
+
+for t in cmake; do
+    command -v "$t" >/dev/null 2>&1 || { echo "$t is not on PATH." >&2; exit 1; }
+done
+
+cmake --preset "$preset" -S "$here/src"
+cmake --build --preset "${preset%%-*}-default" --parallel ${args:-}
+
+if [ "$install" -eq 1 ]; then
+    # Replicates `cmake --install` into a user-writable prefix; no sudo.
+    PRESET="$preset" "$here/src/home_install.sh" --no-build
+fi

--- a/build_xclbin.bat
+++ b/build_xclbin.bat
@@ -1,0 +1,59 @@
+@echo off
+setlocal
+::
+:: Build the NPU design sets (xclbins). Same command, same behaviour, on every
+:: host -- this file and build_xclbin.sh are FORWARDERS, not two implementations.
+::
+::     build_xclbin.bat                 build whatever is not built yet
+::     build_xclbin.bat doctor          can this shell build at all?
+::     build_xclbin.bat list            what sets exist, and are they built?
+::     build_xclbin.bat check           do the built sets match their spec?
+::     build_xclbin.bat build --force   rebuild everything
+::
+:: Everything real is in tools\build_designs.py, which drives BOTH producers
+:: (npu_offload\gemm_rtp\ and open_kernels\) and holds one lock across them.
+:: Nothing about an xclbin is OS-specific -- it is a device artifact (AIE core
+:: ELFs, CDOs, a PDI) with no host code in it.
+::
+:: .bat AND NOT .ps1, DELIBERATELY. The build.ps1 this replaced carried a list
+:: of PowerShell footguns that had each cost somebody a session: `<` is a
+:: RESERVED PARSE OPERATOR, so a pasted `<dst>` placeholder dies naming neither
+:: the placeholder nor what was forgotten; and an undefined `$dst` does not
+:: error, it expands to nothing, so `--out $dst\BERT-...` silently built to the
+:: DRIVE ROOT, four times. A .bat that forwards its arguments has almost no
+:: surface of its own, and it runs from cmd.exe, from PowerShell and from CI
+:: without an execution policy in the way.
+::
+:: Needs the IRON toolchain on PATH:
+::     cd C:\dev\mlir-aie
+::     . .\iron_env.ps1        (MUST be dot-sourced)
+:: `doctor` reports what is missing rather than failing four minutes in.
+
+:: RUN python, do not merely locate it. Windows ships an "App Execution Alias"
+:: stub at %LOCALAPPDATA%\Microsoft\WindowsApps\python.exe which IS on PATH and
+:: which `where python` happily finds -- and which then prints "Python was not
+:: found; run without arguments to install from the Microsoft Store" and exits.
+:: A `where` check passes on such a machine and the build fails one line later
+:: with a message about a store listing. Asking for a version is the only test
+:: that distinguishes an interpreter from a shortcut to a shop.
+python -c "import sys" >nul 2>&1
+if errorlevel 1 (
+    echo No working 'python' on this shell's path.
+    echo ^(If `where python` finds one anyway, it is the Microsoft Store alias
+    echo stub in %%LOCALAPPDATA%%\Microsoft\WindowsApps -- not an interpreter.^)
+    echo.
+    echo     cd C:\dev\mlir-aie
+    echo     . .\iron_env.ps1        ^(MUST be dot-sourced^)
+    echo.
+    echo Then re-run. XILINX_XRT must stay UNSET -- it poisons Windows builds;
+    echo use XRT_ROOT. See docs\design-sets.md.
+    exit /b 1
+)
+
+:: No arguments means the thing you came here for.
+if "%~1"=="" (
+    python "%~dp0tools\build_designs.py" build
+) else (
+    python "%~dp0tools\build_designs.py" %*
+)
+exit /b %ERRORLEVEL%

--- a/build_xclbin.sh
+++ b/build_xclbin.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env sh
+# Build the NPU design sets (xclbins). Same command, same behaviour, on every
+# host -- this file and build_xclbin.bat are FORWARDERS, not two implementations.
+#
+#   ./build_xclbin.sh                 build whatever is not built yet
+#   ./build_xclbin.sh doctor          can this shell build at all?
+#   ./build_xclbin.sh list            what sets exist, and are they built?
+#   ./build_xclbin.sh check           do the built sets match their spec?
+#   ./build_xclbin.sh build --force   rebuild everything
+#
+# Everything real is in tools/build_designs.py, which drives BOTH producers
+# (npu_offload/gemm_rtp/ and open_kernels/) and holds one lock across them.
+# Nothing here is OS-specific: an xclbin is a device artifact -- AIE core ELFs,
+# CDOs, a PDI -- with no host code in it at all. The BERT families were built
+# on Windows and the Qwen sets in WSL through this same path.
+#
+# Needs the IRON toolchain on the interpreter it finds. `doctor` says what is
+# missing instead of failing four minutes in; docs/design-sets.md has the
+# from-scratch recipe.
+set -eu
+
+here=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+PYTHON=${PYTHON:-}
+if [ -z "$PYTHON" ]; then
+    for c in python3 python; do
+        if command -v "$c" >/dev/null 2>&1; then PYTHON=$c; break; fi
+    done
+fi
+if [ -z "$PYTHON" ]; then
+    echo "No python on PATH. Activate the IRON venv first:" >&2
+    echo "    . <venv>/bin/activate     # built from ironvenv-requirements.txt" >&2
+    echo "See docs/design-sets.md." >&2
+    exit 1
+fi
+
+# No arguments means the thing you came here for.
+if [ "$#" -eq 0 ]; then set -- build; fi
+
+exec "$PYTHON" "$here/tools/build_designs.py" "$@"

--- a/docs/design-sets.md
+++ b/docs/design-sets.md
@@ -77,20 +77,77 @@ The mlir-aie checkout is resolved in one place, in this order:
 files used to hardcode three different answers, and a from-scratch build
 followed whichever document its reader found first.
 
-## The shared build cache, and why builds are serialised
+### From scratch in WSL, with no root
 
-IRON's build cache is **global** (`~/.npu/cache`) and `gemm_rtp`'s `purge()`
-deletes entries by **content markers** — `M*K`, `K*N`, `M*N`, the dtypes. Two
-builds can therefore own the same markers, and they do: `qkv` and `attn_out`
+Verified on a clean Ubuntu 24.04 that had only an old mlir-aie 1.3.4 venv —
+which `doctor` correctly refused, because 1.3.4's runtime API cannot build the
+current designs at all (`rt.task_group()` vs `TaskGroup()`, `rt.fill(fifo, …)`
+vs `fifo.fill(…)`).
+
+```bash
+python3 -m venv ~/ironenv142
+~/ironenv142/bin/pip install -r ironvenv-requirements.txt      # mlir-aie 1.4.2 + Peano
+
+# xclbinutil: mlir-aie ships the source, deliberately self-contained
+cmake -B ~/hrx-build -S ~/mlir-aie/third_party/hrx-xclbinutil -DCMAKE_BUILD_TYPE=Release
+cmake --build ~/hrx-build --target hrx-xclbinutil -j$(nproc)
+mkdir -p ~/xrt-tools/bin
+ln -sf ~/hrx-build/tools/hrx-xclbinutil ~/xrt-tools/bin/xclbinutil
+
+export PATH=~/xrt-tools/bin:$PATH
+source ~/ironenv142/bin/activate
+python tools/build_designs.py doctor
+python tools/build_designs.py build --producer open_kernels
+```
+
+`pip`, `cmake`, `g++`. **No XRT install, no Boost, no `sudo`.**
+
+### `aiebu-asm` and `insts.elf`
+
+The one tool that will *not* come from a checkout is `aiebu-asm`: Xilinx/aiebu
+needs Boost, liblzma and liblz4, i.e. a package manager and an administrator.
+It is used by exactly one aiecc step — the last one, emitting `insts.elf` — and
+before this was made conditional, its absence failed the **whole** pipeline
+after the AIE compile and `insts.bin` were already finished.
+
+That step is not on the path to a shipped kernel. `export_qwen36_kernels.py`
+copies `final.xclbin` and `insts.bin`, and nothing else; the ELF is for the C++
+harness (`xrt::elf(insts.elf)`), a different workflow. So `build_design.py`
+skips it when the tool is missing and **says so loudly**, `doctor` reports it as
+a warning naming exactly what is degraded, and a stale `insts.elf` is deleted
+rather than left to look current.
+
+`xclbinutil`, by contrast, is a hard requirement — `doctor` reports its absence
+as a problem, not a warning, because aiecc cannot package an xclbin without it.
+
+## Why builds are serialised — one lock, two different collisions
+
+Do not simplify this to "the shared cache". The two producers destroy a
+concurrent build by different mechanisms, and only one of them involves the
+cache at all.
+
+**`gemm_rtp` collides in the IRON build cache.** It is global (`~/.npu/cache`)
+and `purge()` deletes entries by **content markers** — `M*K`, `K*N`, `M*N`, the
+dtypes. Two builds can own the same markers, and they do: `qkv` and `attn_out`
 depend on neither `--gated-ffn` nor `--intermediate`, so `BERT-h768-bfp16` and
-`BERT-h768-gated-bfp16` share 8 of their 16 entries exactly. Running them
-together is not a race that needs bad luck; it is a guaranteed collision, and
-it surfaces minutes later as a `FileNotFoundError` on a cache hash that names
-nothing.
+`BERT-h768-gated-bfp16` share 8 of their 16 entries exactly. Not a race that
+needs bad luck — a guaranteed collision, surfacing minutes later as a
+`FileNotFoundError` on a cache hash that names nothing.
 
-`build_designs.py` holds one lock across **both** producers for exactly this
-reason — `open_kernels` builds through the same cache. If a build crashes and
-leaves the lock behind, `--force-unlock` clears it.
+**`open_kernels` never touches that cache.** Measured: six sets, 42 minutes,
+**zero** entries left in `~/.npu/cache`, against 125 from a single `gemm_rtp`
+run — `build_design.py` compiles with explicit output paths, and explicit paths
+bypass the JIT cache. It collides somewhere else entirely: `SETS` names **fixed
+build directories inside the working tree** (`designs/layer_x/build_lx0` and
+friends), which are the same paths whatever `--out` says. That also means a
+Windows build and a WSL build of the same set collide even though they have
+different `$HOME`s and therefore different locks.
+
+`build_designs.py` holds one lock across both producers for both reasons. The
+lock directory stays inside `~/.npu/cache` anyway, deliberately: that is the
+path upstream NpuEmbeddings' own `export_gemm_rtp.py` locks, so when a future
+sync brings that copy in, the two meet on the same file instead of each
+guarding a different door. `--force-unlock` clears a lock left by a crash.
 
 > **One gap, stated rather than hidden.** `npu_offload/gemm_rtp/` is a *dumb
 > copy* synced from the upstream NpuEmbeddings repository, so it is not patched

--- a/docs/design-sets.md
+++ b/docs/design-sets.md
@@ -1,0 +1,135 @@
+# NPU design sets: one convention, two producers
+
+The `.xclbin` files this application loads are **built, not checked in**. The
+source is the source, and a binary sitting in a repository beside the code that
+allegedly produces it is a claim nobody checks. That policy only pays for itself
+if rebuilding is easy — so this document is the contract, and
+`tools/build_designs.py` is the one command that honours it.
+
+```
+python tools/build_designs.py doctor    # can this shell build at all?
+python tools/build_designs.py list      # what sets exist, and are they built?
+python tools/build_designs.py build     # build the ones that are missing
+python tools/build_designs.py check     # do the built sets match their spec?
+```
+
+## The two producers
+
+| producer | source | builds | destination |
+|---|---|---|---|
+| `gemm_rtp` | `npu_offload/gemm_rtp/` | 5 BERT/embedding GEMM families | `src/xclbins/BERT-*/gemm_rtp/` |
+| `open_kernels` | `open_kernels/` | 6 Qwen3.6-MoE decode sets | `src/xclbins/Qwen3.6-35B-A3B-NPU2/open_kernels/` |
+
+They are genuinely different things — RTP-parameterised GEMM families against
+21 fused decode designs — and they are **not** being merged. What is shared is
+the contract below, which lives in `tools/npu_designs.py` and nowhere else.
+
+## The output convention
+
+```
+src/xclbins/<model-or-family>/<producer>/
+    toolchain.json          <- provenance, one schema (see below)
+    ...                     <- the producer's own artifacts
+```
+
+`gemm_rtp` writes `design.json` plus its instruction streams into that
+directory; `open_kernels` writes one subdirectory per set, each holding
+`final.xclbin` and `insts.bin`, with `toolchain.json` at the producer level.
+
+**A set is identified by its contents, never by its modification time.** A JIT
+cache hit does not restamp a directory, so "newest wins" silently returns a
+design nobody asked for.
+
+## `toolchain.json` — one schema
+
+`src/open_npue/npu_device.cpp` reads this file and reports `unavailable` for
+any field it does not find, so a missing field degrades **silently**. Adding a
+field is safe; renaming one is not.
+
+| field | meaning |
+|---|---|
+| `schema` | `npu-design-set/1` |
+| `producer` | `gemm_rtp` or `open_kernels` |
+| `built` | local ISO-8601 timestamp |
+| `mlir_aie_version`, `peano_version` | installed package versions |
+| `mlir_aie_root`, `mlir_aie_git_head` | which checkout, at which commit |
+| `source_git_head` | this repository's HEAD at build time |
+| `model`, `sets`, `sha256` | optional; `open_kernels` records all three |
+
+Nothing here is interpreted by the runtime — it only reports it. A field that
+cannot be read is written as `"unavailable"`, never guessed and never omitted,
+because an export must not fail over provenance.
+
+## The toolchain
+
+**One pin, for the whole repository: `ironvenv-requirements.txt`.** It is the
+only place mlir-aie and Peano versions are written down, and
+`build_designs.py doctor` compares it against what is installed.
+
+This matters more than it looks. PR #6 moved the pin to `mlir_aie==1.4.2`
+without touching `npu_offload/gemm_rtp/`, so the BERT sets' documented build
+began running on a toolchain nothing had rebuilt them against — no error, no
+warning, and no way to tell from the artifacts, because the old
+`toolchain.json` recorded only three fields and none of them was checked.
+
+The mlir-aie checkout is resolved in one place, in this order:
+`$MLIR_AIE_ROOT`, `utilities/mlir-aie`, `~/mlir-aie`, `C:\dev\mlir-aie`. Three
+files used to hardcode three different answers, and a from-scratch build
+followed whichever document its reader found first.
+
+## The shared build cache, and why builds are serialised
+
+IRON's build cache is **global** (`~/.npu/cache`) and `gemm_rtp`'s `purge()`
+deletes entries by **content markers** — `M*K`, `K*N`, `M*N`, the dtypes. Two
+builds can therefore own the same markers, and they do: `qkv` and `attn_out`
+depend on neither `--gated-ffn` nor `--intermediate`, so `BERT-h768-bfp16` and
+`BERT-h768-gated-bfp16` share 8 of their 16 entries exactly. Running them
+together is not a race that needs bad luck; it is a guaranteed collision, and
+it surfaces minutes later as a `FileNotFoundError` on a cache hash that names
+nothing.
+
+`build_designs.py` holds one lock across **both** producers for exactly this
+reason — `open_kernels` builds through the same cache. If a build crashes and
+leaves the lock behind, `--force-unlock` clears it.
+
+> **One gap, stated rather than hidden.** `npu_offload/gemm_rtp/` is a *dumb
+> copy* synced from the upstream NpuEmbeddings repository, so it is not patched
+> here — patching a sync target is how the copy stops being a copy. Its
+> `export_gemm_rtp.py` therefore takes no lock of its own in this tree, and
+> invoking it **directly** is unguarded. Go through `build_designs.py` (or
+> `build.ps1`, which now wraps it). Upstream's own copy does take a lock; when a
+> future sync brings it in, the two will meet, and the shared lock is
+> re-entrant across processes via `NPU_DESIGN_BUILD_LOCK` for that reason.
+
+## Where the flags live
+
+**Not here, and not in the shared module.** Each producer keeps its own:
+
+* `npu_offload/gemm_rtp/families.json` — the five families' flags, with the
+  reason each one is what it is. Every flag is load-bearing: a set is selected
+  at load time by geometry **and** datapath, so a wrong flag is not a slower
+  design, it is one the wrong model loads, or none does. Two such defects have
+  shipped, both found by accident from outside.
+* `open_kernels/export_qwen36_kernels.py`'s `SETS` — the six Qwen sets and
+  their compile-time environment knobs.
+
+`build_designs.py` reads both and restates neither.
+
+## What `check` proves
+
+* **`gemm_rtp`** — `families.json` against the built `design.json`, field by
+  field. This catches a flag edited without a rebuild, and a set built by some
+  other route.
+* **both** — every built set carries a readable `toolchain.json` of the current
+  schema, and where hashes were recorded, the files still match them.
+* **`open_kernels --check DIR`** additionally answers *"did this source really
+  produce these bytes?"*: `insts.bin` must be byte-identical, and an
+  `.xclbin` may differ only in the fields `xclbinutil` and `bootgen` stamp per
+  build (the axlf unique id, timestamp and UUID, the PDI UUIDs, the boot-image
+  header id and its checksum, and the `XCLBIN_MIRROR_DATA` tail). Roughly 80
+  bytes per xclbin; every other byte must match.
+
+A set that is **not built** is reported, not failed — nothing is built on a
+fresh clone, and a check that always fails is a check nobody reads.
+`--require-built` makes it an error, which is what the build path passes for
+what it has just built.

--- a/npu_offload/gemm_rtp/README.md
+++ b/npu_offload/gemm_rtp/README.md
@@ -16,10 +16,13 @@ it.
 | `gemm_pretiled.py` | the IRON design: the whole-array pre-tiled GEMM, its ObjectFifo dataflow and the `mm.cc` kernel invocation |
 | `export_gemm_rtp.py` | the driver — builds every (shape, tier) stream against one xclbin and writes the design set |
 | `npue.py` | the container format, for `gemm_b_layout()` / `layout_hash()` and the B-tiling the packer must match |
-| `toolchain_provenance.py` | writes `toolchain.json` beside the design |
+| `toolchain_provenance.py` | writes `toolchain.json` beside the design — a shim over `tools/npu_designs.py`, so both producers write one schema |
 | `families.json` | the five design families and their flags — the ONLY place those are written down |
-| `build.ps1` | builds all five in order, skipping what is already built, then checks them |
+| `build.ps1` | wrapper over `python tools/build_designs.py build --producer gemm_rtp` |
 | `check_design_sets.py` | checks the built sets against `families.json` |
+
+The build itself is one command for the whole repository —
+`tools/build_designs.py`, see [`docs/design-sets.md`](../../docs/design-sets.md).
 
 And **three AIE kernel sources**, one directory over, at
 `npu_offload/m5-eltwise/kernels/` — the path `gemm_pretiled.py` computes for
@@ -72,15 +75,23 @@ Two traps that cost an hour each if you meet them cold:
 
 ```powershell
 cd C:\dev\mlir-aie; . .\iron_env.ps1        # MUST be dot-sourced
-cd <repo>; .\npu_offload\gemm_rtp\build.ps1
+cd <repo>; python tools\build_designs.py doctor      # is this shell able to build?
+cd <repo>; python tools\build_designs.py build --producer gemm_rtp
 ```
 
+`.\npu_offload\gemm_rtp\build.ps1` is the same thing and now wraps it.
+
 That is the whole thing. Five families in order, ~20 minutes, skipping any that
-are already built. `-Force` rebuilds, `-Only <name>` does one, `-Dst <dir>`
-builds elsewhere. It checks the IRON toolchain is on the path *before* spending
-four minutes discovering it is not, and it ends by running
-`check_design_sets.py`, so a green run means the sets exist **and** match the
-flags they were supposed to be built with.
+are already built. `--force` rebuilds, `--only <name>` does one, `--xclbins
+<dir>` builds elsewhere. `doctor` checks the IRON toolchain, the pinned
+versions, `XILINX_XRT` and the build cache *before* spending four minutes
+discovering one of them is wrong, and the build ends by running the check — so
+a green run means the sets exist **and** match the flags they were supposed to
+be built with.
+
+The one command covers the Qwen sets in `open_kernels/` too, and holds a single
+`~/.npu/cache` lock across both, because they build through the same cache.
+→ [`docs/design-sets.md`](../../docs/design-sets.md)
 
 **There are deliberately no commands to copy in this file.** Every one of the
 three ways to get them wrong has now cost somebody a session:
@@ -91,8 +102,12 @@ three ways to get them wrong has now cost somebody a session:
 | `--out $dst\BERT-...` | PowerShell does **not** error on an undefined variable, it expands it to nothing — so this became `--out \BERT-...` and built to the **drive root**. Successfully. Four times. |
 | two families at once | `purge()` deletes matching entries from the shared `~/.npu/cache` on content markers, and `qkv`/`attn_out` depend on neither `--gated-ffn` nor `--intermediate`, so the two hidden-768 families own identical markers for 8 of their 16 entries and each deletes the other's builds |
 
-The third now refuses in under a second (`export_gemm_rtp.py` holds a lock);
-the first two are gone because the commands are.
+The third now refuses in under a second — `tools/build_designs.py` holds one
+`~/.npu/cache` lock across **both** producers in this repository, which matters
+because `open_kernels/` builds through the same cache. Note the boundary:
+`export_gemm_rtp.py` is a dumb copy synced from upstream and is not patched
+here, so invoking it **directly** in this tree is unguarded. Go through the
+entry command. The first two rows are gone because the commands are.
 
 ## The families, and what makes each one different
 

--- a/npu_offload/gemm_rtp/README.md
+++ b/npu_offload/gemm_rtp/README.md
@@ -90,8 +90,8 @@ a green run means the sets exist **and** match the flags they were supposed to
 be built with.
 
 The one command covers the Qwen sets in `open_kernels/` too, and holds a single
-`~/.npu/cache` lock across both, because they build through the same cache.
-→ [`docs/design-sets.md`](../../docs/design-sets.md)
+build lock across both — for two different collisions, only one of which is
+this cache. → [`docs/design-sets.md`](../../docs/design-sets.md)
 
 **There are deliberately no commands to copy in this file.** Every one of the
 three ways to get them wrong has now cost somebody a session:
@@ -103,8 +103,10 @@ three ways to get them wrong has now cost somebody a session:
 | two families at once | `purge()` deletes matching entries from the shared `~/.npu/cache` on content markers, and `qkv`/`attn_out` depend on neither `--gated-ffn` nor `--intermediate`, so the two hidden-768 families own identical markers for 8 of their 16 entries and each deletes the other's builds |
 
 The third now refuses in under a second — `tools/build_designs.py` holds one
-`~/.npu/cache` lock across **both** producers in this repository, which matters
-because `open_kernels/` builds through the same cache. Note the boundary:
+build lock across **both** producers in this repository. Note that
+`open_kernels/` does *not* share this cache (it compiles with explicit output
+paths, which bypass it); it collides in its own fixed build directories
+instead, and one lock covers both. Note the boundary too:
 `export_gemm_rtp.py` is a dumb copy synced from upstream and is not patched
 here, so invoking it **directly** in this tree is unguarded. Go through the
 entry command. The first two rows are gone because the commands are.

--- a/npu_offload/gemm_rtp/build.ps1
+++ b/npu_offload/gemm_rtp/build.ps1
@@ -1,130 +1,67 @@
-# Build every open_npue design set, in order.
+# Build every open_npue (BERT) design set, in order.
 #
 #   cd C:\dev\mlir-aie; . .\iron_env.ps1        # MUST be dot-sourced
 #   cd <repo>; .\npu_offload\gemm_rtp\build.ps1
 #
-# ~3-4 minutes per family, five families, so budget ~20 minutes. Families that
-# are already built are skipped; -Force rebuilds, -Only <name> does one.
+# THIS IS NOW A WRAPPER over `python tools/build_designs.py`, which builds the
+# Qwen sets in open_kernels/ as well and holds ONE ~/.npu/cache lock across
+# both. The loop that used to live here was Windows-only, and the header it
+# carried claimed a guard that this tree does not have:
 #
-# THE FLAGS ARE IN families.json, NOT HERE. One machine-readable source that
-# this script builds from and check_design_sets.py verifies against, so there
-# is no second copy to drift. They used to be five pasteable commands in
-# README.md, and every way of pasting them wrong has now happened to somebody:
+#   "export_gemm_rtp.py holds a lock now and refuses in under a second"
+#
+# It does upstream. The copy in this repository predates that change, so until
+# the entry command took the lock, two builds through the shared cache deleted
+# each other's work exactly as the comment said they would -- and the failure
+# lands minutes later as a FileNotFoundError on a cache hash that names
+# nothing. The other traps the old header recorded are still real and are why
+# nobody should paste build commands by hand:
 #
 #   * `<dst>` -- PowerShell rejects `<` as a reserved operator during PARSING,
-#     so it dies with "The '<' operator is reserved for future use", naming
-#     neither the placeholder nor the substitution that was forgotten.
+#     so it dies naming neither the placeholder nor what was forgotten.
 #   * `$dst` -- PowerShell does NOT error on an undefined variable, it expands
-#     it to nothing, so `--out $dst\BERT-...` becomes `--out \BERT-...` and
-#     resolves to the DRIVE ROOT. Builds fine, three minutes a family, and puts
-#     the set where nothing will ever look for it. Four of them, once.
-#   * Two at once -- purge() deletes matching entries from the SHARED
-#     ~/.npu/cache on content markers, and qkv/attn_out depend on neither
-#     --gated-ffn nor --intermediate, so the two hidden-768 families own
-#     identical markers for 8 of their 16 entries and each deletes the other's
-#     builds. export_gemm_rtp.py holds a lock now and refuses in under a
-#     second; this script is how not to meet it.
+#     it to nothing, so `--out $dst\BERT-...` resolves to the DRIVE ROOT.
+#     Builds fine, three minutes a family, puts the set where nothing looks.
+#
+# THE FLAGS ARE IN families.json, NOT HERE and not in build_designs.py. One
+# machine-readable source that the build reads and check_design_sets.py
+# verifies against, so there is no second copy to drift.
 
 [CmdletBinding()]
 param(
     # Build one family instead of all five, by name (e.g. BERT-h1024-bfp16).
     [string] $Only = "",
-    # Where the sets go. Defaults to the tree this script lives in.
+    # Where the sets go. Defaults to <repo>/src/xclbins.
     [string] $Dst = "",
     # Rebuild even if the set is already there.
-    [switch] $Force
+    [switch] $Force,
+    # Break a stale ~/.npu/cache lock left by a crashed build.
+    [switch] $ForceUnlock
 )
 
 $ErrorActionPreference = 'Stop'
-$here = $PSScriptRoot
-if (-not $Dst) { $Dst = (Join-Path $here '..\..\src\xclbins') }
-$Dst = [IO.Path]::GetFullPath($Dst)
+$entry = Join-Path $PSScriptRoot '..\..\tools\build_designs.py'
+$entry = [IO.Path]::GetFullPath($entry)
 
-$spec = Get-Content (Join-Path $here 'families.json') -Raw | ConvertFrom-Json
-$common = $spec.common
-
-# The IRON toolchain, checked before four minutes of work rather than after.
-# Without `. .\iron_env.ps1` the failure is `ModuleNotFoundError: No module
-# named 'aie'`, which reads as a broken checkout rather than a shell that was
-# never set up.
-& python -c "import aie.iron" 2>$null
-if ($LASTEXITCODE -ne 0) {
-    Write-Host "The IRON toolchain is not on this shell's path." -ForegroundColor Red
+# Without the dot-sourced environment there is no `python` at all, and the
+# failure ("The term 'python' is not recognized") reads as a broken checkout
+# rather than a shell that was never set up.
+if (-not (Get-Command python -ErrorAction SilentlyContinue)) {
+    Write-Host "No 'python' on this shell's path." -ForegroundColor Red
     Write-Host ""
     Write-Host "    cd C:\dev\mlir-aie"
     Write-Host "    . .\iron_env.ps1        # MUST be dot-sourced"
     Write-Host ""
-    Write-Host "Then re-run this script. (Also: XILINX_XRT must stay UNSET --"
-    Write-Host "it poisons Windows builds. Use XRT_ROOT.)"
+    Write-Host "Then re-run. (XILINX_XRT must stay UNSET -- it poisons Windows"
+    Write-Host "builds. Use XRT_ROOT.) For everything else: python tools\build_designs.py doctor"
     exit 1
 }
 
-$families = $spec.families
-if ($Only) {
-    $families = @($families | Where-Object { $_.name -eq $Only })
-    if (-not $families) {
-        Write-Host "No family named '$Only'. Known:" -ForegroundColor Red
-        $spec.families | ForEach-Object { Write-Host "  $($_.name)" }
-        exit 1
-    }
-}
+$argv = @('build', '--producer', 'gemm_rtp')
+if ($Only)        { $argv += @('--only', $Only) }
+if ($Dst)         { $argv += @('--xclbins', [IO.Path]::GetFullPath($Dst)) }
+if ($Force)       { $argv += '--force' }
+if ($ForceUnlock) { $argv += '--force-unlock' }
 
-Write-Host "Building into $Dst"
-Write-Host ""
-$t_all = Get-Date
-$built = 0; $skipped = 0; $failed = @()
-
-foreach ($f in $families) {
-    $out = Join-Path $Dst $f.name
-    if ((Test-Path (Join-Path $out 'gemm_rtp\design.json')) -and -not $Force) {
-        Write-Host ("  {0,-24} already built (use -Force to rebuild)" -f $f.name)
-        $skipped++
-        continue
-    }
-    Write-Host ("  {0,-24} {1}" -f $f.name, ($f.serves -join ', '))
-    if (Test-Path $out) { Remove-Item $out -Recurse -Force }
-
-    $t0 = Get-Date
-    Push-Location $here
-    # 2>&1 | Out-String rather than a redirection: PowerShell 5.1 wraps a
-    # native command's stderr in ErrorRecords, which under -ErrorActionPreference
-    # Stop aborts the whole script on a build that merely printed a warning.
-    $ErrorActionPreference = 'Continue'
-    $log = & python export_gemm_rtp.py @($f.args + $common) --out $out 2>&1 | Out-String
-    $code = $LASTEXITCODE
-    $ErrorActionPreference = 'Stop'
-    Pop-Location
-
-    $secs = [int]((Get-Date) - $t0).TotalSeconds
-    $n = 0
-    if (Test-Path (Join-Path $out 'gemm_rtp')) {
-        $n = (Get-ChildItem (Join-Path $out 'gemm_rtp') -File).Count
-    }
-    if ($code -ne 0) {
-        Write-Host "    FAILED (exit $code) after ${secs}s" -ForegroundColor Red
-        ($log -split "`n" | Select-Object -Last 15) | ForEach-Object { "      $_" }
-        $failed += $f.name
-    } else {
-        Write-Host "    ok  $n files, ${secs}s" -ForegroundColor Green
-        $built++
-    }
-}
-
-Write-Host ""
-Write-Host ("built {0}, skipped {1}, failed {2}  ({3:N0} s total)" -f `
-    $built, $skipped, $failed.Count, ((Get-Date) - $t_all).TotalSeconds)
-
-if ($failed.Count) {
-    Write-Host "failed: $($failed -join ', ')" -ForegroundColor Red
-    exit 1
-}
-
-# The spec and the sets it produced must agree. This catches a flag edited in
-# families.json without a rebuild, and a set built by some other route.
-Write-Host ""
-Write-Host "Checking the built sets against families.json:"
-Push-Location $here
-& python check_design_sets.py --xclbins $Dst
-$rc = $LASTEXITCODE
-Pop-Location
-exit $rc
+& python $entry @argv
+exit $LASTEXITCODE

--- a/npu_offload/gemm_rtp/toolchain_provenance.py
+++ b/npu_offload/gemm_rtp/toolchain_provenance.py
@@ -1,80 +1,48 @@
-# NpuEmbeddings -- toolchain provenance sidecar (T39, tasks/0106).
 # SPDX-License-Identifier: MIT
+# Toolchain provenance sidecar for the gemm_rtp design sets.
 #
-# tasks/0102's audit found that kernel config hash `333c4d33` names TWO
-# different instruction streams -- 0 `crrnd` instructions before the mlir-aie
-# 1.3.4 -> 1.4.2 upgrade, 3 after -- and nothing in the build path could tell
-# them apart; the audit had to fall back on .xclbin MTIME, in a repo whose
-# trap 7c forbids exactly that, because no better source existed
-# (research/notes/0009-toolchain-provenance.md).
+# THE IMPLEMENTATION MOVED to tools/npu_designs.py. It used to live here, and
+# open_kernels/export_qwen36_kernels.py grew its own copy that wrote the same
+# FILENAME with a different SCHEMA -- three fields here, eight there, both
+# called toolchain.json, both landing under src/xclbins/. src/open_npue/
+# npu_device.cpp reads the file and reports "unavailable" for any field it does
+# not find, so the disagreement degrades silently instead of failing. One
+# schema, written by one function, is the fix; this file stays as the name
+# export_gemm_rtp.py imports.
 #
-# This writes a small toolchain.json NEXT TO each design.json the export
-# tools already emit, capturing three strings that are already resident or a
-# cheap call away: the mlir_aie package version, the Peano (llvm-aie) package
-# version, and `git rev-parse HEAD` of C:\dev\mlir-aie. Nothing here is
+# What it records: the mlir_aie and Peano (llvm-aie) package versions, the git
+# HEAD of the mlir-aie checkout and of this repository. Nothing here is
 # interpreted by the runtime -- it only reports it.
 #
-# DELIBERATE DEPARTURE from note 0009's proposal: the note also suggested
-# tools/pack_npue.py copy a design's toolchain.json into the .npue container
-# header. That is NOT done here. A .npue is packed from HuggingFace weights
-# and never invokes mlir-aie at all, so a design's toolchain is not a
-# property of the container -- the relationship between designs and
-# containers is many-to-many in both directions (tasks/0104 gave MiniLM and
-# bge-small different designs at the same geometry). Baking a design's build
-# string into a container would assert a 1:1 relationship that does not
-# exist, the same mistake the datapath field would have been if it had been
-# put in the container instead of design.json. toolchain.json lives ONLY next
-# to design.json, in the artifacts directory.
-#
-# Never fails a build: an export must not die because provenance couldn't be
-# established. A field that can't be read is recorded as "unavailable", never
+# Never fails a build: an export must not die because provenance could not be
+# established. A field that cannot be read is recorded as "unavailable", never
 # guessed at and never a raised exception.
+#
+# DELIBERATE DEPARTURE from the original proposal: the packer does NOT copy a
+# design's toolchain.json into the .npue container header. A container is packed
+# from HuggingFace weights and never invokes mlir-aie, so a design's toolchain
+# is not a property of the container -- the relationship between designs and
+# containers is many-to-many in both directions. toolchain.json lives ONLY next
+# to design.json, in the artifacts directory.
 
 from __future__ import annotations
 
-import json
-import subprocess
+import sys
 from pathlib import Path
 
-MLIR_AIE_ROOT = Path(r"C:\dev\mlir-aie")
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+from npu_designs import mlir_aie_root, write_toolchain_json as _write  # noqa: E402
+
+MLIR_AIE_ROOT = mlir_aie_root()
 
 
-def _pkg_version(name: str) -> str:
-    try:
-        import importlib.metadata as m
-        return m.version(name)
-    except Exception:
-        return "unavailable"
-
-
-def _git_head(root: Path) -> str:
-    try:
-        out = subprocess.run(
-            ["git", "-C", str(root), "rev-parse", "HEAD"],
-            capture_output=True, text=True, timeout=10)
-        if out.returncode != 0:
-            return "unavailable"
-        head = out.stdout.strip()
-        return head if head else "unavailable"
-    except Exception:
-        return "unavailable"
-
-
-def write_toolchain_json(out_dir: Path,
-                         mlir_aie_root: Path = MLIR_AIE_ROOT) -> dict:
+def write_toolchain_json(out_dir, mlir_aie_root=None) -> dict:
     """Write toolchain.json next to design.json in `out_dir`.
 
-    Three strings, all best-effort: a failure to read any one of them
-    degrades that field to "unavailable" rather than raising, because
-    provenance is not worth failing an export over.
+    `mlir_aie_root` is accepted for compatibility and ignored: the shared module
+    resolves the checkout the same way for every producer, so a build no longer
+    depends on which of three documented locations the caller happened to know
+    about (C:\\dev\\mlir-aie here, ~/ironenv142 in open_kernels, ironvenv +
+    utilities/mlir-aie in AGENTS.md).
     """
-    info = {
-        "mlir_aie_version": _pkg_version("mlir_aie"),
-        "peano_version": _pkg_version("llvm-aie"),
-        "mlir_aie_git_head": _git_head(mlir_aie_root),
-    }
-    out_dir = Path(out_dir)
-    out_dir.mkdir(parents=True, exist_ok=True)
-    (out_dir / "toolchain.json").write_text(json.dumps(info, indent=2),
-                                            encoding="utf-8")
-    return info
+    return _write(Path(out_dir), producer="gemm_rtp")

--- a/open_kernels/README.md
+++ b/open_kernels/README.md
@@ -5,6 +5,14 @@
 > (`fixture_paths.py`). For building and running the designs from THIS tree use
 > `harness/README.md` (`run_kernel`, synthetic fixtures, 1.4.2 pin); for the six
 > kernel sets the engine loads, `export_qwen36_kernels.py` (`src/open_qwen36/README.md`).
+>
+> **The six sets build from the repository's one entry command** —
+> `python tools/build_designs.py build --producer open_kernels` — which holds a
+> single `~/.npu/cache` lock across this producer and `npu_offload/gemm_rtp/`,
+> because both build through that cache and its entries are purged by content.
+> `export_qwen36_kernels.py` still works directly and takes the same lock. The
+> `toolchain.json` schema, the device pin and the xclbin comparison are shared:
+> `tools/npu_designs.py`, described in [`../docs/design-sets.md`](../docs/design-sets.md).
 
 # open-kernels — our own NPU kernels (IRON / mlir-aie), driven by phlegm
 

--- a/open_kernels/build_design.py
+++ b/open_kernels/build_design.py
@@ -10,6 +10,23 @@ run(opcode=3, 0, 0, bo...).
 
 The design module must expose DESIGN (an @iron.jit callable) and SPECIALIZE
 (dict of CompileTime kwargs).
+
+insts.elf is OPTIONAL and is skipped, loudly, when `aiebu-asm` is not
+available. It is aiecc's last pipeline step (26 of 38 on the ln design) and it
+is the only step that needs that tool -- so requiring it made the build of the
+kernels the ENGINE loads depend on a tool whose output the engine never reads:
+export_qwen36_kernels.py ships final.xclbin and insts.bin, and nothing else.
+The ELF is for the C++ harness (`xrt::elf(insts.elf)`), which is a different
+workflow with a different audience.
+
+That distinction is worth a whole environment. With the ELF skipped, a
+from-scratch WSL clone builds every set with pip, cmake and g++: mlir-aie and
+Peano come from ironvenv-requirements.txt, and xclbinutil from
+mlir-aie's own third_party/hrx-xclbinutil, which is deliberately self-contained
+("No Boost, no system XRT, no submodule"). aiebu-asm is the one piece that is
+not: Xilinx/aiebu needs Boost, liblzma and liblz4, i.e. root on the machine.
+Making the ELF conditional is the difference between "needs a package manager
+and an administrator" and "needs a checkout".
 """
 
 from __future__ import annotations
@@ -21,7 +38,7 @@ import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
-from npu_designs import set_current_device  # noqa: E402
+from npu_designs import find_aiebu_asm, set_current_device  # noqa: E402
 
 
 def main() -> int:
@@ -42,16 +59,33 @@ def main() -> int:
     sys.path.insert(0, str(src.parent))
     spec.loader.exec_module(mod)
 
+    # aiecc emits insts.elf via aiebu-asm and fails the WHOLE pipeline when the
+    # tool is absent -- after the AIE compile and insts.bin are already done.
+    # Skip that one step rather than lose the build; say so, because the harness
+    # does need the ELF and a silent omission would surface as a missing file
+    # much later, somewhere else.
+    aiebu = find_aiebu_asm()
+    kwargs = dict(xclbin_path=str(out / "final.xclbin"),
+                  inst_path=str(out / "insts.bin"))
+    if aiebu:
+        kwargs["elf_path"] = str(out / "insts.elf")
+    else:
+        (out / "insts.elf").unlink(missing_ok=True)   # never leave a stale one
+        print("  WARNING: aiebu-asm not found -- building WITHOUT insts.elf.\n"
+              "           final.xclbin and insts.bin are complete, which is all\n"
+              "           export_qwen36_kernels.py ships and all the engine\n"
+              "           loads. The C++ harness (xrt::elf(insts.elf)) will NOT\n"
+              "           run against this build. Install XRT, or Xilinx/aiebu\n"
+              "           (needs Boost, liblzma, liblz4), and rebuild.",
+              flush=True)
+
     t0 = time.time()
-    xclbin, insts = mod.DESIGN.specialize(**mod.SPECIALIZE).compile(
-        xclbin_path=str(out / "final.xclbin"),
-        inst_path=str(out / "insts.bin"),
-        elf_path=str(out / "insts.elf"),
-    )
+    xclbin, insts = mod.DESIGN.specialize(**mod.SPECIALIZE).compile(**kwargs)
     dt = time.time() - t0
     for p in sorted(out.iterdir()):
         print(f"  {p.name:24s} {p.stat().st_size:>10d} B")
-    print(f"BUILD_OK {src.name} -> {out}  ({dt:.1f}s)")
+    print(f"BUILD_OK {src.name} -> {out}  ({dt:.1f}s)"
+          + ("" if aiebu else "  [no insts.elf]"))
     return 0
 
 

--- a/open_kernels/build_design.py
+++ b/open_kernels/build_design.py
@@ -20,8 +20,8 @@ import sys
 import time
 from pathlib import Path
 
-import aie.iron as iron
-from aie.iron.device import from_name
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+from npu_designs import set_current_device  # noqa: E402
 
 
 def main() -> int:
@@ -33,8 +33,9 @@ def main() -> int:
     shutil.rmtree(out / "final.prj", ignore_errors=True)
     out.mkdir(parents=True, exist_ok=True)
 
-    # Trap 1 (LLMNpuTest): without this IRON silently targets aie2 / NPU1.
-    iron.set_current_device(from_name("npu2", n_cols=None))
+    # Without this IRON silently targets aie2 / NPU1 -- see tools/npu_designs.py
+    # for what that costs and why it is invisible.
+    set_current_device()
 
     spec = importlib.util.spec_from_file_location(src.stem, src)
     mod = importlib.util.module_from_spec(spec)

--- a/open_kernels/export_qwen36_kernels.py
+++ b/open_kernels/export_qwen36_kernels.py
@@ -40,8 +40,10 @@ DESIGNS = HERE / "designs"
 DEFAULT_OUT = REPO / "src" / "xclbins" / "Qwen3.6-35B-A3B-NPU2" / "open_kernels"
 
 # The build-side facts this producer shares with npu_offload/gemm_rtp/: the
-# toolchain.json schema, the ~/.npu/cache lock (both producers build through
-# that cache, and its entries are purged by content), and the xclbin comparison
+# toolchain.json schema, the build lock (this producer does NOT use the IRON
+# cache -- explicit output paths bypass it, measured at zero entries for six
+# sets -- but SETS below names fixed build directories in the working tree,
+# which collide just as surely), and the xclbin comparison
 # that used to live in this file. That comparison moved because "did this source
 # really produce these bytes?" is the only honest test of a repository that
 # ships source instead of binaries, and BOTH producers make that claim.
@@ -49,7 +51,7 @@ DEFAULT_OUT = REPO / "src" / "xclbins" / "Qwen3.6-35B-A3B-NPU2" / "open_kernels"
 # compile-time knobs are written down.
 sys.path.insert(0, str(REPO / "tools"))
 from npu_designs import (  # noqa: E402
-    CacheLock, artifacts_equivalent, sha256_file, write_toolchain_json,
+    BuildLock, artifacts_equivalent, sha256_file, write_toolchain_json,
 )
 
 # name -> (design source, build dir, compile-time environment)
@@ -103,10 +105,12 @@ def main() -> int:
 
     out_root = Path(a.out).resolve()
     hashes: dict[str, str] = {}
-    # One build at a time through the shared IRON cache. --no-build only copies
-    # and hashes what is already there, so it needs no lock and must not take
-    # one -- it is the operation you run while a build is going.
-    with CacheLock(a.force_unlock, what="export_qwen36_kernels.py") if not a.no_build \
+    # One build at a time: SETS names fixed build directories in the working
+    # tree, so a second build of the same set overwrites this one's whatever
+    # --out says. --no-build only copies and hashes what is already there, so it
+    # needs no lock and must not take one -- it is the operation you run WHILE a
+    # build is going.
+    with BuildLock(a.force_unlock, what="export_qwen36_kernels.py") if not a.no_build \
             else contextlib.nullcontext():
         for n in names:
             bdir = SETS[n][1] if a.no_build else build(n)

--- a/open_kernels/export_qwen36_kernels.py
+++ b/open_kernels/export_qwen36_kernels.py
@@ -26,11 +26,9 @@ xclbin and nowhere else (see src/open_qwen36/README.md).
 from __future__ import annotations
 
 import argparse
-import hashlib
-import json
+import contextlib
 import os
 import shutil
-import struct
 import subprocess
 import sys
 import time
@@ -40,6 +38,19 @@ HERE = Path(__file__).resolve().parent                 # open_kernels/
 REPO = HERE.parent
 DESIGNS = HERE / "designs"
 DEFAULT_OUT = REPO / "src" / "xclbins" / "Qwen3.6-35B-A3B-NPU2" / "open_kernels"
+
+# The build-side facts this producer shares with npu_offload/gemm_rtp/: the
+# toolchain.json schema, the ~/.npu/cache lock (both producers build through
+# that cache, and its entries are purged by content), and the xclbin comparison
+# that used to live in this file. That comparison moved because "did this source
+# really produce these bytes?" is the only honest test of a repository that
+# ships source instead of binaries, and BOTH producers make that claim.
+# Flags stay local: SETS below is still the only place the Qwen sets'
+# compile-time knobs are written down.
+sys.path.insert(0, str(REPO / "tools"))
+from npu_designs import (  # noqa: E402
+    CacheLock, artifacts_equivalent, sha256_file, write_toolchain_json,
+)
 
 # name -> (design source, build dir, compile-time environment)
 # The build dirs are the ones the batch harness (model/make_decode.py) and the
@@ -56,79 +67,6 @@ SETS = {
 # knobs that must NOT leak in from the caller's shell
 CLEAR = ("LX_PART", "LX_STOP", "AX_PART", "LMHEAD_N", "LMHEAD_CORES")
 FILES = ("final.xclbin", "insts.bin")
-
-
-def sha256(p: Path) -> str:
-    h = hashlib.sha256()
-    with p.open("rb") as f:
-        for chunk in iter(lambda: f.read(1 << 20), b""):
-            h.update(chunk)
-    return h.hexdigest()
-
-
-def xclbin_volatile_ranges(x: bytes) -> list[tuple[int, int]]:
-    """Byte ranges of an xclbin that legitimately change from build to build.
-
-    axlf layout (xrt/include/xclbin.h): m_uniqueId @296, header.m_timeStamp
-    @312, header.uuid @416, m_numSections @448, section headers @456 (40 B
-    each: kind u32, name[16], pad, offset u64, size u64). Kind 32 is
-    AIE_PARTITION: its aie_pdi array (array_offset @+120, 96 B entries) holds a
-    per-build UUID per PDI, and each PDI image is a bootgen boot image whose
-    image header carries a per-build unique id (@+0x98) and the header checksum
-    that covers it (@+0xCC). The bytes after the last section are xclbinutil's
-    XCLBIN_MIRROR_DATA JSON, a copy of the header. Nothing else -- the CDOs,
-    the AIE core ELFs, the metadata sections -- may differ."""
-    if x[:7] != b"xclbin2":
-        return []
-    ranges = [(296, 304), (312, 320), (416, 432)]
-    n = struct.unpack_from("<I", x, 448)[0]
-    end = 456 + n * 40
-    for i in range(n):
-        off = 456 + i * 40
-        kind = struct.unpack_from("<I", x, off)[0]
-        so, sz = struct.unpack_from("<QQ", x, off + 24)
-        end = max(end, so + sz)
-        if kind == 32:
-            n_pdi, off_pdi = struct.unpack_from("<II", x, so + 120)
-            for k in range(n_pdi):
-                e = so + off_pdi + k * 96
-                ranges.append((e, e + 16))                               # aie_pdi.uuid
-                img_size, img_off = struct.unpack_from("<II", x, e + 16)  # aie_pdi.pdi_image
-                if img_size >= 0xD0:
-                    ranges.append((so + img_off + 0x98, so + img_off + 0x9C))   # image header unique id
-                    ranges.append((so + img_off + 0xCC, so + img_off + 0xD0))   # image header checksum
-    ranges.append((end, len(x)))
-    return ranges
-
-
-def xclbin_equivalent(a: bytes, b: bytes) -> tuple[bool, str]:
-    """True when a and b differ only in build stamps (UUIDs / timestamps / ids)."""
-    if len(a) != len(b):
-        return False, f"sizes differ ({len(a)} vs {len(b)} B)"
-    ranges = xclbin_volatile_ranges(a)
-    diff = [i for i in range(len(a)) if a[i] != b[i]]
-    if not diff:
-        return True, "byte-identical"
-    stray = [i for i in diff if not any(lo <= i < hi for lo, hi in ranges)]
-    if stray:
-        return False, f"{len(stray)} bytes differ outside the build-stamp fields (first @{stray[0]})"
-    return True, f"{len(diff)} bytes differ, all build stamps (uuid/timestamp/unique id)"
-
-
-def pkg_version(name: str) -> str:
-    try:
-        import importlib.metadata as m
-        return m.version(name)
-    except Exception:
-        return "unavailable"
-
-
-def git_head(root: Path) -> str:
-    try:
-        r = subprocess.run(["git", "-C", str(root), "rev-parse", "HEAD"], capture_output=True, text=True, timeout=10)
-        return r.stdout.strip() or "unavailable"
-    except Exception:
-        return "unavailable"
 
 
 def build(name: str) -> Path:
@@ -155,6 +93,8 @@ def main() -> int:
     ap.add_argument("--check", metavar="DIR",
                     help="a previous export (or a shipped xclbins/<model>/open_kernels dir) to compare "
                          "against; non-zero exit on any difference beyond the per-build UUID/timestamp stamps")
+    ap.add_argument("--force-unlock", action="store_true",
+                    help="break a stale ~/.npu/cache lock left by a crashed build")
     a = ap.parse_args()
     names = [n.strip() for n in a.only.split(",") if n.strip()]
     bad = [n for n in names if n not in SETS]
@@ -163,47 +103,34 @@ def main() -> int:
 
     out_root = Path(a.out).resolve()
     hashes: dict[str, str] = {}
-    for n in names:
-        bdir = SETS[n][1] if a.no_build else build(n)
-        dst = out_root / n
-        dst.mkdir(parents=True, exist_ok=True)
-        for f in FILES:
-            srcf = bdir / f
-            if not srcf.is_file():
-                sys.exit(f"[{n}] {srcf} missing after build")
-            shutil.copyfile(srcf, dst / f)
-            key = f"{n}/{f}"
-            hashes[key] = sha256(dst / f)
-            print(f"  {hashes[key]}  {key}  ({(dst / f).stat().st_size} B)")
+    # One build at a time through the shared IRON cache. --no-build only copies
+    # and hashes what is already there, so it needs no lock and must not take
+    # one -- it is the operation you run while a build is going.
+    with CacheLock(a.force_unlock, what="export_qwen36_kernels.py") if not a.no_build \
+            else contextlib.nullcontext():
+        for n in names:
+            bdir = SETS[n][1] if a.no_build else build(n)
+            dst = out_root / n
+            dst.mkdir(parents=True, exist_ok=True)
+            for f in FILES:
+                srcf = bdir / f
+                if not srcf.is_file():
+                    sys.exit(f"[{n}] {srcf} missing after build")
+                shutil.copyfile(srcf, dst / f)
+                key = f"{n}/{f}"
+                hashes[key] = sha256_file(dst / f)
+                print(f"  {hashes[key]}  {key}  ({(dst / f).stat().st_size} B)")
 
-    info = {
-        "model": "Qwen3.6-35B-A3B-NPU2",
-        "built": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
-        "mlir_aie_version": pkg_version("mlir_aie"),
-        "peano_version": pkg_version("llvm-aie"),
-        "mlir_aie_git_head": git_head(Path(os.environ.get("MLIR_AIE_ROOT", Path.home() / "mlir-aie"))),
-        "source_git_head": git_head(REPO),
-        "sets": {n: {"design": SETS[n][0].relative_to(REPO).as_posix(), "env": SETS[n][2]} for n in names},
-        "sha256": hashes,
-    }
-    # Keep what an earlier run recorded when this one did not build everything:
-    # a subset rebuild merges its sets/hashes in, and --no-build (which may run
-    # outside the toolchain venv) keeps the recorded versions instead of
-    # overwriting them with "unavailable".
-    tj = out_root / "toolchain.json"
-    if tj.is_file() and (a.no_build or len(names) < len(SETS)):
-        try:
-            old = json.loads(tj.read_text(encoding="utf-8"))
-            for k in ("sets", "sha256"):
-                merged = dict(old.get(k, {}))
-                merged.update(info[k])
-                info[k] = merged
-            if a.no_build:
-                for k in ("built", "mlir_aie_version", "peano_version", "mlir_aie_git_head", "source_git_head"):
-                    info[k] = old.get(k, info[k])
-        except Exception:
-            pass
-    tj.write_text(json.dumps(info, indent=2) + "\n", encoding="utf-8")
+    # One toolchain.json schema for every design set in the repo -- see
+    # tools/npu_designs.py. `merge` keeps what an earlier run recorded when this
+    # one built a subset, or ran outside the toolchain venv and would otherwise
+    # overwrite real versions with "unavailable".
+    info = write_toolchain_json(
+        out_root, producer="open_kernels", model="Qwen3.6-35B-A3B-NPU2",
+        sets={n: {"design": SETS[n][0].relative_to(REPO).as_posix(),
+                  "env": SETS[n][2]} for n in names},
+        sha256=hashes,
+        merge=(a.no_build or len(names) < len(SETS)))
     print(f"-> {out_root}  (toolchain.json: mlir-aie {info['mlir_aie_version']}, Peano {info['peano_version']})")
 
     if a.check:
@@ -215,11 +142,7 @@ def main() -> int:
                 print(f"MISSING  {key}: not in {ref}")
                 bad += 1
                 continue
-            x, y = mine.read_bytes(), theirs.read_bytes()
-            if key.endswith("insts.bin"):
-                ok, note = (x == y), ("byte-identical" if x == y else f"differ ({len(x)} vs {len(y)} B)")
-            else:
-                ok, note = xclbin_equivalent(x, y)
+            ok, note = artifacts_equivalent(mine, theirs)
             print(f"{'same    ' if ok else 'MISMATCH'} {key}: {note}")
             bad += not ok
         if bad:

--- a/tools/build_designs.py
+++ b/tools/build_designs.py
@@ -16,14 +16,16 @@ export_qwen36_kernels.py (WSL venv, six Qwen sets), with three different
 documented toolchain locations between them and AGENTS.md.
 
 This does not replace either producer and does not restate a single one of
-their flags. It finds them, runs them, holds one lock across both (they share
-~/.npu/cache, and entries there are purged by content), and checks what came
-out. `build.ps1` still works and now calls through here.
+their flags. It finds them, runs them, holds one lock across both, and checks
+what came out. `build.ps1` still works and now calls through here.
 
 WHAT IT CANNOT DO. Building needs the IRON toolchain on the current
-interpreter -- `doctor` says so plainly rather than failing four minutes in.
-The Qwen sets additionally need xclbinutil/aiebu-asm on PATH, which is why they
-are normally built in WSL.
+interpreter, and an `xclbinutil` -- `doctor` says so plainly rather than
+failing four minutes in. Nothing here is OS-specific: an xclbin is a device
+artifact (AIE core ELFs, CDOs, a PDI) with no host code in it, and the five
+BERT families were built on Windows and the six Qwen sets in WSL against this
+same file. `insts.elf` is the one output that needs a tool (`aiebu-asm`) which
+is not obtainable without root; it is skipped, loudly, when absent.
 """
 from __future__ import annotations
 
@@ -38,6 +40,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import npu_designs as nd  # noqa: E402
+from npu_designs import find_aiebu_asm  # noqa: E402
 
 GEMM_RTP = nd.REPO / "npu_offload" / "gemm_rtp"
 OPEN_KERNELS = nd.REPO / "open_kernels"
@@ -115,17 +118,28 @@ def cmd_doctor(args) -> int:
                                  "Use XRT_ROOT.".format(os.environ["XILINX_XRT"]))
     else:
         ok("XILINX_XRT unset")
-    for tool in ("xclbinutil", "aiebu-asm"):
-        p = shutil.which(tool)
-        (ok if p else note)(tool, p or "not on PATH (needed for the Qwen sets)")
+    p = shutil.which("xclbinutil")
+    (ok if p else fail)(
+        "xclbinutil", p or "not on PATH -- aiecc cannot package an xclbin. "
+                           "Build mlir-aie's own\n           "
+                           "third_party/hrx-xclbinutil (self-contained: no "
+                           "Boost, no system XRT)\n           and symlink it "
+                           "onto PATH as `xclbinutil`.")
+    p = find_aiebu_asm()
+    (ok if p else note)(
+        "aiebu-asm", str(p) if p else
+        "not found -- builds proceed WITHOUT insts.elf.\n           "
+        "final.xclbin and insts.bin are unaffected, so the Qwen sets and the\n"
+        "           engine are fine; the C++ harness (xrt::elf) is not. Needs "
+        "XRT, or\n           Xilinx/aiebu (Boost + liblzma + liblz4, i.e. root).")
 
-    print("\nbuild cache")
-    owner = nd.CacheLock.owner()
+    print("\nbuild lock")
+    owner = nd.BuildLock.owner()
     if owner:
-        note("~/.npu/cache free", "locked by {} -- another build is running, or "
-                                  "the lock is stale".format(owner))
+        note("no build running", "locked by {} -- another build is running, or "
+                                 "the lock is stale (--force-unlock)".format(owner))
     else:
-        ok("~/.npu/cache free", str(nd.CACHE))
+        ok("no build running", str(nd.CACHE / ".export.lock") + " is free")
 
     print("\n{} problem(s), {} warning(s)".format(bad, warn))
     return 1 if bad else 0
@@ -240,10 +254,11 @@ def cmd_build(args) -> int:
     print("Building into {}".format(out_root))
     failed = []
     t0 = time.time()
-    # ONE lock across both producers: they share ~/.npu/cache, where entries are
-    # purged by content markers, so a Qwen build and a BERT build running
-    # together delete each other's work exactly as two BERT builds would.
-    with nd.CacheLock(force=args.force_unlock, what="build_designs.py"):
+    # ONE lock across both producers, for two DIFFERENT collisions: gemm_rtp
+    # shares ~/.npu/cache, whose entries are purged by content markers, while
+    # open_kernels bypasses that cache entirely and instead writes fixed build
+    # directories inside the working tree. See tools/npu_designs.py.
+    with nd.BuildLock(force=args.force_unlock, what="build_designs.py"):
         # Set only AFTER the lock is held: a producer this script invokes sees
         # the variable and inherits the lock instead of deadlocking on it.
         os.environ["NPU_DESIGN_BUILD_LOCK"] = str(os.getpid())

--- a/tools/build_designs.py
+++ b/tools/build_designs.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+r"""Build and verify every NPU design set in this repository, from one command.
+
+    python tools/build_designs.py doctor     # is this shell able to build at all?
+    python tools/build_designs.py list       # what sets exist, and are they built?
+    python tools/build_designs.py build      # build the ones that are missing
+    python tools/build_designs.py check      # do the built sets match their spec?
+
+WHY THIS EXISTS. The xclbins in src/xclbins/ are deliberately NOT checked in --
+the source is the source, and a binary sitting beside the code that allegedly
+produces it is a claim nobody checks. That policy only works if rebuilding is
+easy, and until this file there was no single way in: npu_offload/gemm_rtp/ had
+build.ps1 (Windows, PowerShell, five BERT families) and open_kernels/ had
+export_qwen36_kernels.py (WSL venv, six Qwen sets), with three different
+documented toolchain locations between them and AGENTS.md.
+
+This does not replace either producer and does not restate a single one of
+their flags. It finds them, runs them, holds one lock across both (they share
+~/.npu/cache, and entries there are purged by content), and checks what came
+out. `build.ps1` still works and now calls through here.
+
+WHAT IT CANNOT DO. Building needs the IRON toolchain on the current
+interpreter -- `doctor` says so plainly rather than failing four minutes in.
+The Qwen sets additionally need xclbinutil/aiebu-asm on PATH, which is why they
+are normally built in WSL.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import npu_designs as nd  # noqa: E402
+
+GEMM_RTP = nd.REPO / "npu_offload" / "gemm_rtp"
+OPEN_KERNELS = nd.REPO / "open_kernels"
+PRODUCERS = ("gemm_rtp", "open_kernels")
+
+
+def rel(p) -> str:
+    try:
+        return Path(p).resolve().relative_to(nd.REPO).as_posix()
+    except Exception:
+        return str(p)
+
+
+# --------------------------------------------------------------------------
+# doctor
+# --------------------------------------------------------------------------
+
+def cmd_doctor(args) -> int:
+    """Everything a build needs, checked before the build rather than during."""
+    bad = warn = 0
+
+    def ok(label, detail=""):
+        print("  ok       {:<26} {}".format(label, detail))
+
+    def fail(label, detail=""):
+        nonlocal bad
+        bad += 1
+        print("  MISSING  {:<26} {}".format(label, detail))
+
+    def note(label, detail=""):
+        nonlocal warn
+        warn += 1
+        print("  warn     {:<26} {}".format(label, detail))
+
+    print("interpreter")
+    ok("python", "{} ({})".format(
+        ".".join(str(x) for x in sys.version_info[:3]), sys.executable))
+
+    print("\nIRON toolchain")
+    try:
+        import aie.iron  # noqa: F401
+        ok("import aie.iron")
+        iron_ok = True
+    except Exception as e:
+        fail("import aie.iron", "{}: {}".format(type(e).__name__, e))
+        print("           This shell cannot build. On Windows:")
+        print("             cd C:\\dev\\mlir-aie; . .\\iron_env.ps1   "
+              "# MUST be dot-sourced")
+        print("           On Linux/WSL, activate the venv built from "
+              "ironvenv-requirements.txt.")
+        iron_ok = False
+
+    pins = nd.required_pins()
+    for pkg, want in sorted(pins.items()):
+        got = nd.pkg_version(pkg)
+        if got == "unavailable":
+            (note if not iron_ok else fail)(pkg, "pinned {}, not installed".format(want))
+        elif got.split("+")[0] != want.split("+")[0]:
+            note(pkg, "pinned {}, installed {}".format(want, got))
+        else:
+            ok(pkg, got)
+    if not pins:
+        note("ironvenv-requirements.txt", "no == pins found")
+
+    root = nd.mlir_aie_root()
+    if (root / "utils").is_dir() or (root / ".git").exists():
+        ok("mlir-aie checkout", "{}  (head {})".format(root, nd.git_head(root)[:12]))
+    else:
+        note("mlir-aie checkout", "{} does not exist -- provenance will read "
+                                  "'unavailable'".format(root))
+
+    print("\nenvironment")
+    if os.environ.get("XILINX_XRT"):
+        fail("XILINX_XRT unset", "it is set to {!r}; it poisons Windows builds. "
+                                 "Use XRT_ROOT.".format(os.environ["XILINX_XRT"]))
+    else:
+        ok("XILINX_XRT unset")
+    for tool in ("xclbinutil", "aiebu-asm"):
+        p = shutil.which(tool)
+        (ok if p else note)(tool, p or "not on PATH (needed for the Qwen sets)")
+
+    print("\nbuild cache")
+    owner = nd.CacheLock.owner()
+    if owner:
+        note("~/.npu/cache free", "locked by {} -- another build is running, or "
+                                  "the lock is stale".format(owner))
+    else:
+        ok("~/.npu/cache free", str(nd.CACHE))
+
+    print("\n{} problem(s), {} warning(s)".format(bad, warn))
+    return 1 if bad else 0
+
+
+# --------------------------------------------------------------------------
+# list
+# --------------------------------------------------------------------------
+
+def cmd_list(args) -> int:
+    sets = nd.all_sets(args.xclbins)
+    width = max(len(s.name) for s in sets)
+    last = None
+    for s in sets:
+        if s.producer != last:
+            src = GEMM_RTP if s.producer == "gemm_rtp" else OPEN_KERNELS
+            print("\n{}  (source: {}/)".format(s.producer, rel(src)))
+            last = s.producer
+        tj = nd.read_toolchain_json(s.dest if s.producer == "gemm_rtp"
+                                    else s.dest.parent)
+        stamp = ""
+        if s.built and tj:
+            stamp = "  mlir-aie {}".format(tj.get("mlir_aie_version", "?"))
+        print("  {:<3} {:<{w}}  {:<38} {}{}".format(
+            "[x]" if s.built else "[ ]", s.name, ", ".join(s.serves) or "-",
+            rel(s.dest), stamp, w=width))
+    n = sum(1 for s in sets if s.built)
+    print("\n{} of {} built.  [ ] = not built here; "
+          "`build_designs.py build` makes it.".format(n, len(sets)))
+    return 0
+
+
+# --------------------------------------------------------------------------
+# build
+# --------------------------------------------------------------------------
+
+def build_gemm_rtp(names, out_root, force) -> list:
+    """Run export_gemm_rtp.py once per family, with families.json's own flags.
+
+    This is build.ps1's loop, in Python so there is one implementation for both
+    platforms. The flags come from families.json and are not repeated here --
+    that file says, correctly, that it is the only place they are written."""
+    spec = nd.gemm_rtp_spec()
+    common = list(spec["common"])
+    failed = []
+    for fam in spec["families"]:
+        if fam["name"] not in names:
+            continue
+        out = Path(out_root) / fam["name"]
+        if (out / "gemm_rtp" / "design.json").is_file() and not force:
+            print("  {:<24} already built (--force rebuilds)".format(fam["name"]))
+            continue
+        print("  {:<24} {}".format(fam["name"], ", ".join(fam.get("serves") or [])))
+        if out.exists():
+            shutil.rmtree(out, ignore_errors=True)
+        t0 = time.time()
+        r = subprocess.run(
+            [sys.executable, "export_gemm_rtp.py"] + list(fam["args"]) + common
+            + ["--out", str(out)],
+            cwd=str(GEMM_RTP))
+        dt = int(time.time() - t0)
+        if r.returncode != 0:
+            print("    FAILED (exit {}) after {}s".format(r.returncode, dt))
+            failed.append(fam["name"])
+        else:
+            n = len(list((out / "gemm_rtp").glob("*"))) if (out / "gemm_rtp").is_dir() else 0
+            print("    ok  {} files, {}s".format(n, dt))
+    return failed
+
+
+def build_open_kernels(names, out_root, force) -> list:
+    dst = Path(out_root) / "Qwen3.6-35B-A3B-NPU2" / "open_kernels"
+    todo = [n for n in names
+            if force or not all((dst / n / f).is_file() for f in nd.ARTIFACTS)]
+    if not todo:
+        print("  all requested sets already built (--force rebuilds)")
+        return []
+    print("  {}".format(", ".join(todo)))
+    r = subprocess.run(
+        [sys.executable, "export_qwen36_kernels.py", "--out", str(dst),
+         "--only", ",".join(todo)],
+        cwd=str(OPEN_KERNELS))
+    return [] if r.returncode == 0 else ["open_kernels"]
+
+
+def cmd_build(args) -> int:
+    out_root = Path(args.xclbins or nd.XCLBINS)
+    sets = nd.all_sets(out_root)
+    wanted = set(n.strip() for n in args.only.split(",") if n.strip()) if args.only else None
+    if wanted:
+        known = {s.name for s in sets}
+        unknown = wanted - known
+        if unknown:
+            sys.exit("unknown set(s) {}; try `build_designs.py list`".format(sorted(unknown)))
+
+    plan = {}
+    for s in sets:
+        if args.producer and s.producer != args.producer:
+            continue
+        if wanted and s.name not in wanted:
+            continue
+        plan.setdefault(s.producer, []).append(s.name)
+    if not plan:
+        sys.exit("nothing selected")
+
+    try:
+        import aie.iron  # noqa: F401
+    except Exception:
+        sys.exit("the IRON toolchain is not importable on this interpreter.\n"
+                 "Run `python tools/build_designs.py doctor` for what is missing.")
+
+    print("Building into {}".format(out_root))
+    failed = []
+    t0 = time.time()
+    # ONE lock across both producers: they share ~/.npu/cache, where entries are
+    # purged by content markers, so a Qwen build and a BERT build running
+    # together delete each other's work exactly as two BERT builds would.
+    with nd.CacheLock(force=args.force_unlock, what="build_designs.py"):
+        # Set only AFTER the lock is held: a producer this script invokes sees
+        # the variable and inherits the lock instead of deadlocking on it.
+        os.environ["NPU_DESIGN_BUILD_LOCK"] = str(os.getpid())
+        for producer, names in plan.items():
+            print("\n{}:".format(producer))
+            if producer == "gemm_rtp":
+                failed += build_gemm_rtp(names, out_root, args.force)
+            else:
+                failed += build_open_kernels(names, out_root, args.force)
+        os.environ.pop("NPU_DESIGN_BUILD_LOCK", None)
+
+    print("\n{} failed, {:.0f}s total".format(len(failed), time.time() - t0))
+    if failed:
+        print("failed: {}".format(", ".join(failed)))
+        return 1
+    print("\nChecking what was just built:")
+    return check(out_root, args.producer, require_built=True)
+
+
+# --------------------------------------------------------------------------
+# check
+# --------------------------------------------------------------------------
+
+def check_gemm_rtp_spec(s, problems) -> None:
+    """families.json (the flags) against design.json (what got built).
+
+    Every wrong flag here produces a perfectly valid design set, and a set is
+    selected at load time by geometry AND datapath -- so a wrong flag is not a
+    slower design, it is one the wrong model loads or none does. Two such
+    defects have shipped, both found by accident from outside."""
+    sys.path.insert(0, str(GEMM_RTP))
+    try:
+        import check_design_sets as cds
+    finally:
+        sys.path.pop(0)
+    spec = nd.gemm_rtp_spec()
+    fam = next(f for f in spec["families"] if f["name"] == s.name)
+    want = cds.expected(list(fam["args"]) + list(spec["common"]))
+    got = cds.actual(json.loads((s.dest / "design.json").read_text(encoding="utf-8")))
+    for k in want:
+        if want[k] is not None and want[k] != got.get(k):
+            problems.append("{}: {} -- families.json says {!r}, design.json "
+                            "says {!r}".format(s.name, k, want[k], got.get(k)))
+
+
+def check_provenance(s, problems, warnings) -> None:
+    """Every built set carries a toolchain.json this repo can read, and the
+    files still hash to what that file recorded."""
+    d = s.dest if s.producer == "gemm_rtp" else s.dest.parent
+    tj = nd.read_toolchain_json(d)
+    if tj is None:
+        problems.append("{}: no readable toolchain.json in {}".format(s.name, rel(d)))
+        return
+    if tj.get("schema") != nd.SCHEMA:
+        warnings.append("{}: toolchain.json predates schema {} (rebuild to "
+                        "refresh)".format(s.name, nd.SCHEMA))
+    if tj.get("mlir_aie_version", "unavailable") == "unavailable":
+        warnings.append("{}: toolchain.json records no mlir-aie version".format(s.name))
+    for key, want in (tj.get("sha256") or {}).items():
+        if not key.startswith(s.name + "/"):
+            continue
+        f = d / key
+        if not f.is_file():
+            problems.append("{}: {} recorded in toolchain.json but missing".format(
+                s.name, key))
+        elif nd.sha256_file(f) != want:
+            problems.append("{}: {} does not match the sha256 toolchain.json "
+                            "recorded".format(s.name, key))
+
+
+def check(xclbins, producer, require_built=False) -> int:
+    sets = [s for s in nd.all_sets(xclbins)
+            if not producer or s.producer == producer]
+    problems, warnings, missing = [], [], []
+    for s in sets:
+        if not s.built:
+            missing.append(s)
+            continue
+        before = len(problems)
+        if s.producer == "gemm_rtp":
+            check_gemm_rtp_spec(s, problems)
+        check_provenance(s, problems, warnings)
+        print("  {:<8} {}".format("MISMATCH" if len(problems) > before else "ok", s.name))
+    for s in missing:
+        print("  {:<8} {}  ({})".format(
+            "MISSING" if require_built else "not built", s.name, rel(s.dest)))
+
+    for w in warnings:
+        print("\nwarn     {}".format(w))
+    for p in problems:
+        print("\nMISMATCH {}".format(p))
+
+    bad = len(problems) + (len(missing) if require_built else 0)
+    print("\n{} of {} set(s) built, {} problem(s), {} warning(s)".format(
+        len(sets) - len(missing), len(sets), len(problems), len(warnings)))
+    if problems:
+        print("\nEither the set is stale -- rebuild it with `build_designs.py "
+              "build --force` --\nor the spec is wrong, in which case fix it "
+              "in families.json and nowhere else.")
+    elif missing and not require_built:
+        print("\nSets that are not built here are reported, not failed: nothing "
+              "is built on a fresh\nclone, and a check that always fails is one "
+              "nobody reads. --require-built makes it an error.")
+    return 1 if bad else 0
+
+
+def cmd_check(args) -> int:
+    return check(args.xclbins, args.producer, args.require_built)
+
+
+# --------------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    def common(p, xclbins=True):
+        if xclbins:
+            p.add_argument("--xclbins", default=None,
+                           help="destination root (default src/xclbins)")
+        p.add_argument("--producer", choices=PRODUCERS, default=None)
+
+    p = sub.add_parser("doctor", help="check this shell can build")
+    p.set_defaults(func=cmd_doctor)
+
+    p = sub.add_parser("list", help="every design set, and whether it is built")
+    common(p)
+    p.set_defaults(func=cmd_list)
+
+    p = sub.add_parser("build", help="build the sets that are missing")
+    common(p)
+    p.add_argument("--only", default="", help="comma-separated set names")
+    p.add_argument("--force", action="store_true", help="rebuild built sets too")
+    p.add_argument("--force-unlock", action="store_true",
+                   help="break a stale ~/.npu/cache lock")
+    p.set_defaults(func=cmd_build)
+
+    p = sub.add_parser("check", help="built sets against their own spec")
+    common(p)
+    p.add_argument("--require-built", action="store_true",
+                   help="treat a set that is not built as an error")
+    p.set_defaults(func=cmd_check)
+
+    args = ap.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/npu_designs.py
+++ b/tools/npu_designs.py
@@ -18,12 +18,22 @@ drifted apart by the time this file was written:
     mlir_aie_git_head); open_kernels writes eight. src/open_npue/npu_device.cpp
     reads the file and reports "unavailable" for anything missing, so a set
     built by the wrong producer degrades silently rather than failing.
-  * The IRON build cache (~/.npu/cache) is GLOBAL and gemm_rtp's purge() deletes
-    entries by content markers. npu_offload/gemm_rtp/build.ps1 states in its own
-    header that "export_gemm_rtp.py holds a lock now and refuses in under a
-    second" -- and in this tree it does not: the lock was added upstream after
-    the copy was taken. Two producers now share that cache, so the guard matters
-    more than it did when it went missing.
+  * Concurrent builds destroy each other, and npu_offload/gemm_rtp/build.ps1
+    stated in its own header that a guard existed ("export_gemm_rtp.py holds a
+    lock now and refuses in under a second") which this tree does not have --
+    the lock was added upstream after the copy was taken. The two producers get
+    there by DIFFERENT routes, which is worth knowing before trusting one lock
+    to cover both:
+      - gemm_rtp collides in the IRON build cache: ~/.npu/cache is global and
+        purge() deletes entries by CONTENT markers, so two families that share
+        a shape delete each other's freshly built entries.
+      - open_kernels does NOT touch that cache at all. Measured: six sets, 42
+        minutes, ZERO entries left in ~/.npu/cache, against 125 from one
+        gemm_rtp run -- because build_design.py compiles with explicit output
+        paths, and explicit paths bypass the JIT cache. It collides somewhere
+        else: SETS names FIXED build directories inside the repo
+        (designs/layer_x/build_lx0 and friends), so two builds of the same set
+        overwrite each other's working tree whatever --out says.
   * mlir-aie is looked for in three places by three files: C:\dev\mlir-aie
     (toolchain_provenance.py), ~/ironenv142 (open_kernels), ironvenv +
     utilities/mlir-aie (AGENTS.md). A from-scratch build follows whichever
@@ -119,6 +129,24 @@ def required_pins() -> dict:
     return pins
 
 
+def find_aiebu_asm():
+    """Where aiecc looks for aiebu-asm, asked the same way aiecc asks.
+
+    Read out of the aiecc binary's own strings rather than guessed: PATH, then
+    /opt/xilinx/xrt/bin, /usr/bin, /opt/xilinx/aiebu/bin. Checking only PATH
+    would report "missing" on a machine where aiecc is perfectly happy, and a
+    build tool that disagrees with the compiler about what is installed is
+    worse than no check."""
+    p = shutil.which("aiebu-asm")
+    if p:
+        return Path(p)
+    for d in ("/opt/xilinx/xrt/bin", "/usr/bin", "/opt/xilinx/aiebu/bin"):
+        c = Path(d) / "aiebu-asm"
+        if c.is_file():
+            return c
+    return None
+
+
 def set_current_device() -> None:
     """Pin IRON to npu2 BEFORE any kernel is created.
 
@@ -136,20 +164,29 @@ def set_current_device() -> None:
 # the shared build cache, and the lock that keeps two producers out of it
 # --------------------------------------------------------------------------
 
-class CacheLock:
-    """Refuse to start while another export owns ~/.npu/cache.
+class BuildLock:
+    """Refuse to start while another NPU design build is running.
 
-    gemm_rtp's purge() rmtree's every cache entry whose markers match, and the
-    markers are CONTENT -- M*K, K*N, M*N, the dtypes. Two builds can therefore
-    own the same marker set, and they do: qkv and attn_out depend on neither
-    --gated-ffn nor --intermediate, so BERT-h768-bfp16 and BERT-h768-gated-bfp16
-    share 8 of their 16 entries exactly. Running them together is not a race
-    that needs bad luck; it is a guaranteed collision, and it surfaces minutes
-    later as a FileNotFoundError on a cache hash that names nothing.
+    ONE lock, TWO different collisions -- do not simplify this to "the cache":
 
-    It is in the shared module rather than in one producer because open_kernels
-    builds through the same cache. A lock only export_gemm_rtp.py takes does not
-    protect a gemm_rtp build from a concurrent Qwen build.
+      - gemm_rtp: purge() rmtree's every ~/.npu/cache entry whose markers match,
+        and the markers are CONTENT -- M*K, K*N, M*N, the dtypes. qkv and
+        attn_out depend on neither --gated-ffn nor --intermediate, so
+        BERT-h768-bfp16 and BERT-h768-gated-bfp16 share 8 of their 16 entries
+        exactly. Not a race that needs bad luck; a guaranteed collision, landing
+        minutes later as a FileNotFoundError on a cache hash that names nothing.
+      - open_kernels: never touches that cache (explicit output paths bypass the
+        JIT cache -- measured, six sets and zero entries). It collides in the
+        FIXED build directories under open_kernels/designs/, which are part of
+        the working tree and are the same paths whatever --out says.
+
+    The lock DIRECTORY is nonetheless kept inside ~/.npu/cache, and that is
+    deliberate: it is the path upstream NpuEmbeddings' own export_gemm_rtp.py
+    locks. When a future sync brings that copy in, the two meet on the same
+    file rather than each guarding a different door.
+
+    A lock only export_gemm_rtp.py takes does not protect a gemm_rtp build from
+    a concurrent Qwen build, which is why it lives here and not in a producer.
 
     It is re-entrant ACROSS PROCESSES through NPU_DESIGN_BUILD_LOCK, which
     build_designs.py sets for its children. Without that, the one entry command

--- a/tools/npu_designs.py
+++ b/tools/npu_designs.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+r"""Shared build-side facts for every NPU design set in this repository.
+
+WHY THIS EXISTS. Two independent producers build xclbins here:
+
+    npu_offload/gemm_rtp/   -> src/xclbins/BERT-h*/gemm_rtp/
+    open_kernels/           -> src/xclbins/Qwen3.6-35B-A3B-NPU2/open_kernels/
+
+They arrived through different pull requests and each invented the same
+conventions separately -- build from source, do not check the binaries in, drop
+a toolchain.json beside them, offer a --check that proves the source really is
+the source. Independently invented conventions drift, and three had already
+drifted apart by the time this file was written:
+
+  * `toolchain.json` names the same file in both trees with DIFFERENT schemas.
+    gemm_rtp writes three fields (mlir_aie_version, peano_version,
+    mlir_aie_git_head); open_kernels writes eight. src/open_npue/npu_device.cpp
+    reads the file and reports "unavailable" for anything missing, so a set
+    built by the wrong producer degrades silently rather than failing.
+  * The IRON build cache (~/.npu/cache) is GLOBAL and gemm_rtp's purge() deletes
+    entries by content markers. npu_offload/gemm_rtp/build.ps1 states in its own
+    header that "export_gemm_rtp.py holds a lock now and refuses in under a
+    second" -- and in this tree it does not: the lock was added upstream after
+    the copy was taken. Two producers now share that cache, so the guard matters
+    more than it did when it went missing.
+  * mlir-aie is looked for in three places by three files: C:\dev\mlir-aie
+    (toolchain_provenance.py), ~/ironenv142 (open_kernels), ironvenv +
+    utilities/mlir-aie (AGENTS.md). A from-scratch build follows whichever
+    document it found first.
+
+So the rule is: anything two producers must agree about lives here, and nowhere
+else. Flags do NOT live here -- npu_offload/gemm_rtp/families.json and
+open_kernels/export_qwen36_kernels.py's SETS remain the only places their own
+knobs are written down. This module is the contract between them, not a third
+copy of their content.
+"""
+from __future__ import annotations
+
+import datetime
+import hashlib
+import json
+import os
+import re
+import shutil
+import struct
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+CACHE = Path.home() / ".npu" / "cache"
+XCLBINS = REPO / "src" / "xclbins"
+
+# Bumped only when a field changes meaning. Readers (npu_device.cpp) treat an
+# absent field as "unavailable", so ADDING one is safe and renaming one is not.
+SCHEMA = "npu-design-set/1"
+
+ARTIFACTS = ("final.xclbin", "insts.bin")
+
+
+# --------------------------------------------------------------------------
+# toolchain: where it is, what version, one answer for both producers
+# --------------------------------------------------------------------------
+
+def mlir_aie_root() -> Path:
+    """Where the mlir-aie checkout lives, in the order a build should try.
+
+    Three files each hardcoded a different answer. This resolves the same way
+    everywhere and, crucially, RETURNS SOMETHING even when nothing exists, so
+    provenance degrades to "unavailable" instead of raising in an export."""
+    env = os.environ.get("MLIR_AIE_ROOT")
+    candidates = [Path(env)] if env else []
+    candidates += [
+        REPO / "utilities" / "mlir-aie",   # AGENTS.md / this repo's submodule
+        Path.home() / "mlir-aie",          # open_kernels' WSL layout
+        Path(r"C:\dev\mlir-aie"),          # the Windows layout gemm_rtp was written on
+    ]
+    for c in candidates:
+        if (c / ".git").exists() or (c / "utils").is_dir():
+            return c
+    return candidates[0]
+
+
+def pkg_version(name: str) -> str:
+    try:
+        import importlib.metadata as m
+        return m.version(name)
+    except Exception:
+        return "unavailable"
+
+
+def git_head(root: Path) -> str:
+    try:
+        r = subprocess.run(["git", "-C", str(root), "rev-parse", "HEAD"],
+                           capture_output=True, text=True, timeout=10)
+        return r.stdout.strip() or "unavailable"
+    except Exception:
+        return "unavailable"
+
+
+def required_pins() -> dict:
+    """The versions ironvenv-requirements.txt pins, as {package: version}.
+
+    One pinned toolchain for the whole repository is the point: PR #6 moved it
+    to mlir_aie 1.4.2 without touching npu_offload/gemm_rtp/, so the BERT sets'
+    documented build now runs on a toolchain nothing had rebuilt them against.
+    `build_designs.py doctor` compares this against what is installed."""
+    pins = {}
+    req = REPO / "ironvenv-requirements.txt"
+    if not req.is_file():
+        return pins
+    for line in req.read_text(encoding="utf-8").splitlines():
+        line = line.split("#", 1)[0].strip()
+        m = re.match(r"^([A-Za-z0-9_.\-]+)\s*==\s*([^\s;]+)$", line)
+        if m:
+            pins[m.group(1).replace("-", "_")] = m.group(2)
+    return pins
+
+
+def set_current_device() -> None:
+    """Pin IRON to npu2 BEFORE any kernel is created.
+
+    Without it _detect_arch() falls back to aie2 (NPU1) with no error and no
+    change to what iron.get_current_device() reports: bf16 mac_dims become
+    (4,8,4) instead of (4,8,8), emulate_bf16_mmul_with_bfp16 turns into a no-op
+    worth 5.5x, and the maximum shim DMA burst halves from 512 B to 256 B.
+    n_cols=None matters too -- from_name("npu2") alone defaults to ONE column."""
+    import aie.iron as iron
+    from aie.iron.device import from_name
+    iron.set_current_device(from_name("npu2", n_cols=None))
+
+
+# --------------------------------------------------------------------------
+# the shared build cache, and the lock that keeps two producers out of it
+# --------------------------------------------------------------------------
+
+class CacheLock:
+    """Refuse to start while another export owns ~/.npu/cache.
+
+    gemm_rtp's purge() rmtree's every cache entry whose markers match, and the
+    markers are CONTENT -- M*K, K*N, M*N, the dtypes. Two builds can therefore
+    own the same marker set, and they do: qkv and attn_out depend on neither
+    --gated-ffn nor --intermediate, so BERT-h768-bfp16 and BERT-h768-gated-bfp16
+    share 8 of their 16 entries exactly. Running them together is not a race
+    that needs bad luck; it is a guaranteed collision, and it surfaces minutes
+    later as a FileNotFoundError on a cache hash that names nothing.
+
+    It is in the shared module rather than in one producer because open_kernels
+    builds through the same cache. A lock only export_gemm_rtp.py takes does not
+    protect a gemm_rtp build from a concurrent Qwen build.
+
+    It is re-entrant ACROSS PROCESSES through NPU_DESIGN_BUILD_LOCK, which
+    build_designs.py sets for its children. Without that, the one entry command
+    holding the lock and then invoking a producer that also takes it would
+    deadlock against itself -- the failure a naive shared lock introduces the
+    day someone wires the second caller up."""
+
+    ENV = "NPU_DESIGN_BUILD_LOCK"
+
+    def __init__(self, force: bool = False, what: str = ""):
+        self.dir = CACHE / ".export.lock"
+        self.force = force
+        self.what = what
+        self.held = False
+        self.inherited = False
+
+    def __enter__(self):
+        if os.environ.get(self.ENV):
+            self.inherited = True
+            return self
+        CACHE.mkdir(parents=True, exist_ok=True)
+        if self.force and self.dir.exists():
+            shutil.rmtree(self.dir, ignore_errors=True)
+        try:
+            self.dir.mkdir()                      # atomic on Windows and POSIX
+        except FileExistsError:
+            who = ""
+            try:
+                who = (self.dir / "owner").read_text(encoding="utf-8").strip()
+            except OSError:
+                pass
+            raise SystemExit(
+                "another NPU design build already owns " + str(CACHE)
+                + (" (" + who + ")" if who else "")
+                + "\n\nRun them ONE AT A TIME. The IRON build cache is shared"
+                  " and entries are purged by\ncontent markers, so two builds"
+                  " delete each other's work -- guaranteed, not unlucky.\n"
+                  "If nothing is running, the lock is stale: pass"
+                  " --force-unlock.")
+        (self.dir / "owner").write_text(
+            "pid {}, {}, started {:%Y-%m-%d %H:%M:%S}".format(
+                os.getpid(), self.what or "npu design build",
+                datetime.datetime.now()),
+            encoding="utf-8")
+        self.held = True
+        return self
+
+    def __exit__(self, *exc):
+        if self.held:
+            shutil.rmtree(self.dir, ignore_errors=True)
+            self.held = False
+        return False
+
+    @staticmethod
+    def owner():
+        try:
+            return ((CACHE / ".export.lock" / "owner")
+                    .read_text(encoding="utf-8").strip())
+        except OSError:
+            return None
+
+
+# --------------------------------------------------------------------------
+# toolchain.json -- ONE schema, written by both producers
+# --------------------------------------------------------------------------
+
+def write_toolchain_json(out_dir, producer, model=None, sets=None,
+                         sha256=None, merge=False) -> dict:
+    """Write toolchain.json into out_dir. Never raises: an export must not die
+    because provenance could not be established, so a field that cannot be read
+    is recorded as "unavailable" -- never guessed, never omitted.
+
+    `merge` keeps what an earlier run recorded when this one built a subset (or
+    ran outside the toolchain venv and would otherwise overwrite real versions
+    with "unavailable")."""
+    info = {
+        "schema": SCHEMA,
+        "producer": producer,
+        "built": datetime.datetime.now().astimezone().strftime(
+            "%Y-%m-%dT%H:%M:%S%z"),
+        "mlir_aie_version": pkg_version("mlir_aie"),
+        "peano_version": pkg_version("llvm-aie"),
+        "mlir_aie_root": str(mlir_aie_root()),
+        "mlir_aie_git_head": git_head(mlir_aie_root()),
+        "source_git_head": git_head(REPO),
+    }
+    if model:
+        info["model"] = model
+    if sets is not None:
+        info["sets"] = sets
+    if sha256 is not None:
+        info["sha256"] = sha256
+
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    tj = out_dir / "toolchain.json"
+    if merge and tj.is_file():
+        try:
+            old = json.loads(tj.read_text(encoding="utf-8"))
+            for k in ("sets", "sha256"):
+                if k in old:
+                    merged = dict(old[k])
+                    merged.update(info.get(k) or {})
+                    info[k] = merged
+            for k in ("built", "mlir_aie_version", "peano_version",
+                      "mlir_aie_git_head", "source_git_head"):
+                if info[k] == "unavailable":
+                    info[k] = old.get(k, info[k])
+        except Exception:
+            pass
+    tj.write_text(json.dumps(info, indent=2) + "\n", encoding="utf-8")
+    return info
+
+
+def read_toolchain_json(d):
+    try:
+        return json.loads((Path(d) / "toolchain.json").read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def sha256_file(p) -> str:
+    h = hashlib.sha256()
+    with Path(p).open("rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+# --------------------------------------------------------------------------
+# "is the source really the source?" -- xclbin comparison
+# --------------------------------------------------------------------------
+
+def xclbin_volatile_ranges(x: bytes) -> list:
+    """Byte ranges of an xclbin that legitimately change from build to build.
+
+    axlf layout (xrt/include/xclbin.h): m_uniqueId @296, header.m_timeStamp
+    @312, header.uuid @416, m_numSections @448, section headers @456 (40 B each:
+    kind u32, name[16], pad, offset u64, size u64). Kind 32 is AIE_PARTITION:
+    its aie_pdi array (array_offset @+120, 96 B entries) holds a per-build UUID
+    per PDI, and each PDI image is a bootgen boot image whose image header
+    carries a per-build unique id (@+0x98) and the header checksum that covers
+    it (@+0xCC). The bytes after the last section are xclbinutil's
+    XCLBIN_MIRROR_DATA JSON, a copy of the header. Nothing else -- the CDOs, the
+    AIE core ELFs, the metadata sections -- may differ.
+
+    Written for open_kernels/export_qwen36_kernels.py --check; it lives here now
+    because the same question ("did this source produce these bytes?") is the
+    only honest test of a repository that ships source and not binaries, and
+    both producers make that claim."""
+    if x[:7] != b"xclbin2":
+        return []
+    ranges = [(296, 304), (312, 320), (416, 432)]
+    n = struct.unpack_from("<I", x, 448)[0]
+    end = 456 + n * 40
+    for i in range(n):
+        off = 456 + i * 40
+        kind = struct.unpack_from("<I", x, off)[0]
+        so, sz = struct.unpack_from("<QQ", x, off + 24)
+        end = max(end, so + sz)
+        if kind == 32:
+            n_pdi, off_pdi = struct.unpack_from("<II", x, so + 120)
+            for k in range(n_pdi):
+                e = so + off_pdi + k * 96
+                ranges.append((e, e + 16))                               # aie_pdi.uuid
+                img_size, img_off = struct.unpack_from("<II", x, e + 16)  # aie_pdi.pdi_image
+                if img_size >= 0xD0:
+                    ranges.append((so + img_off + 0x98, so + img_off + 0x9C))
+                    ranges.append((so + img_off + 0xCC, so + img_off + 0xD0))
+    ranges.append((end, len(x)))
+    return ranges
+
+
+def xclbin_equivalent(a: bytes, b: bytes):
+    """True when a and b differ only in per-build stamps (UUIDs/timestamps/ids)."""
+    if len(a) != len(b):
+        return False, "sizes differ ({} vs {} B)".format(len(a), len(b))
+    ranges = xclbin_volatile_ranges(a)
+    diff = [i for i in range(len(a)) if a[i] != b[i]]
+    if not diff:
+        return True, "byte-identical"
+    stray = [i for i in diff if not any(lo <= i < hi for lo, hi in ranges)]
+    if stray:
+        return False, ("{} bytes differ outside the build-stamp fields "
+                       "(first @{})".format(len(stray), stray[0]))
+    return True, "{} bytes differ, all build stamps".format(len(diff))
+
+
+def artifacts_equivalent(mine, theirs):
+    """Compare one built artifact against a reference. insts.bin must be
+    byte-identical; an xclbin may differ only in the fields xclbinutil and
+    bootgen stamp per build."""
+    x, y = Path(mine).read_bytes(), Path(theirs).read_bytes()
+    if Path(mine).suffix == ".xclbin":
+        return xclbin_equivalent(x, y)
+    if x == y:
+        return True, "byte-identical"
+    if len(x) != len(y):
+        return False, "sizes differ ({} vs {} B)".format(len(x), len(y))
+    n = sum(1 for a, b in zip(x, y) if a != b)
+    return False, "{} of {} bytes differ".format(n, len(x))
+
+
+# --------------------------------------------------------------------------
+# the registry: every design set in the repo, from each producer's OWN spec
+# --------------------------------------------------------------------------
+
+@dataclass
+class DesignSet:
+    producer: str
+    name: str
+    dest: Path
+    serves: list = field(default_factory=list)
+    note: str = ""
+
+    @property
+    def built(self) -> bool:
+        d = self.dest
+        if self.producer == "gemm_rtp":
+            return (d / "design.json").is_file()
+        return all((d / f).is_file() for f in ARTIFACTS)
+
+
+def gemm_rtp_spec() -> dict:
+    return json.loads((REPO / "npu_offload" / "gemm_rtp" / "families.json")
+                      .read_text(encoding="utf-8"))
+
+
+def gemm_rtp_sets(xclbins=None) -> list:
+    root = Path(xclbins or XCLBINS)
+    return [DesignSet("gemm_rtp", f["name"], root / f["name"] / "gemm_rtp",
+                      list(f.get("serves") or []), f.get("note", ""))
+            for f in gemm_rtp_spec()["families"]]
+
+
+def open_kernels_sets(xclbins=None) -> list:
+    """Read open_kernels' own SETS table rather than restating it."""
+    sys.path.insert(0, str(REPO / "open_kernels"))
+    try:
+        import export_qwen36_kernels as q
+        names = list(q.SETS)
+    except Exception:
+        return []
+    finally:
+        sys.path.pop(0)
+    root = Path(xclbins or XCLBINS) / "Qwen3.6-35B-A3B-NPU2" / "open_kernels"
+    return [DesignSet("open_kernels", n, root / n, ["qwen3.6-moe:35b-a3b"], "")
+            for n in names]
+
+
+def all_sets(xclbins=None) -> list:
+    return gemm_rtp_sets(xclbins) + open_kernels_sets(xclbins)


### PR DESCRIPTION
…ducers

Two producers build design sets in this repository -- npu_offload/gemm_rtp/ (five BERT/embedding GEMM families) and open_kernels/ (six Qwen3.6-MoE decode sets). They arrived through different pull requests and each invented the same conventions separately: build from source, do not check the binaries in, drop a toolchain.json beside them, offer a --check that proves the source really is the source. Independently invented conventions drift, and three had already drifted:

  * toolchain.json named the same file with DIFFERENT schemas -- three fields from gemm_rtp, eight from open_kernels, both landing under src/xclbins/. src/open_npue/npu_device.cpp reads it and reports "unavailable" for anything it does not find, so the disagreement degraded silently instead of failing.
  * The IRON build cache (~/.npu/cache) is GLOBAL and gemm_rtp's purge() deletes entries by CONTENT markers, so two builds delete each other's work -- guaranteed, not unlucky: qkv and attn_out depend on neither --gated-ffn nor --intermediate, so the two hidden-768 families share 8 of their 16 entries exactly. build.ps1's own header claimed "export_gemm_rtp.py holds a lock now and refuses in under a second". In this tree it does not: that copy predates the upstream change. Meanwhile open_kernels became a second client of the same cache.
  * mlir-aie was looked for in three places by three files (C:\dev\mlir-aie, ~/ironenv142, ironvenv + utilities/mlir-aie), so a from-scratch build followed whichever document its reader found first.

Nothing here merges the two producers -- they build genuinely different things -- and NOT ONE FLAG MOVES. families.json and export_qwen36_kernels.py's SETS remain the only places their own knobs are written down; the new code reads both and restates neither.

New:

  tools/npu_designs.py    everything two producers must agree about: the
                          toolchain.json schema, the shared cache lock, the npu2
                          device pin, the xclbin comparison (moved out of
                          export_qwen36_kernels.py, because "did this source
                          produce these bytes?" is the only honest test of a
                          repo that ships source, and both producers make that
                          claim), and a registry that reads each producer's own
                          spec.
  tools/build_designs.py  doctor | list | build | check -- one command, both
                          platforms, one lock held across both producers.
  docs/design-sets.md     the output convention, the schema, and the one gap
                          this does not close, stated rather than hidden.

Changed:

  toolchain_provenance.py     now a shim over the shared writer. The three
                              fields it wrote keep their names, so npu_device.cpp
                              is unaffected; five more are added.
  export_qwen36_kernels.py    takes the shared lock (--force-unlock), uses the
                              shared hash/compare/provenance; 73 lines of
                              duplicated code deleted. --no-build deliberately
                              takes NO lock: it is what you run while a build is
                              going.
  build_design.py             shared device pin.
  build.ps1                   a wrapper over the entry command, and its false
                              claim about the lock corrected. It also stops with
                              the dot-source instructions when there is no
                              `python` at all, rather than "the term 'python' is
                              not recognized".

Verified by building all five BERT families from an empty src/xclbins through the new entry command on this machine (Windows, C:\dev\mlir-aie IRON env): five families, 20 files each, `check` green against families.json, and every set carrying the new toolchain.json. The lock was visibly held by build_designs.py throughout.

doctor earned its place on the first run: it reports mlir_aie pinned 1.4.2, installed 1.4.2.dev16+g7e00b57. The sets on this machine are built by a dev build, not the pinned release. The old toolchain.json recorded the version and nothing ever compared it to the pin.

Not verified here: the six Qwen sets. They need WSL with xclbinutil/aiebu-asm and were not rebuilt for this change; their code paths are exercised only by import, --help and the shared-module unit checks.