### PR TITLE
Pull in the upstream FLM sampler fast path and the prefill-length shift fix

### DIFF
--- a/src/common/AutoModel/automodel.cpp
+++ b/src/common/AutoModel/automodel.cpp
@@ -223,8 +223,12 @@ bool AutoModel::_shared_insert(chat_meta_info_t& meta_info, std::vector<int>& to
 
 buffer<bf16> AutoModel::_chunked_insert(chat_meta_info_t& meta_info, std::vector<int>& tokens, std::function<bool()> is_cancelled, void* payload, int first_len_run) {
     int max_prefill_len = meta_info.max_prefill_len;
-    // make max_prefill_len a 2^n
-    max_prefill_len = 1 << static_cast<int>(std::ceil(std::log2(max_prefill_len)));
+    // log2 of a non-positive length is not a number to shift by; an unset or
+    // degenerate limit means "no chunking", which the < 512 branch below already means.
+    if (max_prefill_len > 0) {
+        // make max_prefill_len a 2^n
+        max_prefill_len = 1 << static_cast<int>(std::ceil(std::log2(max_prefill_len)));
+    }
     buffer<bf16> y;
     if (max_prefill_len < 512) {
         y = this->lm_engine->prefill(tokens, payload);
@@ -320,7 +324,9 @@ std::string AutoModel::_shared_generate(chat_meta_info_t& meta_info, int length_
         this->token_history.push_back(sampled_token);
         if (this->is_eos(sampled_token)){
             meta_info.generated_tokens++;
-            this->lm_engine->forward(last_sampled_token);
+            if (this->forward_on_eos) {
+                this->lm_engine->forward(last_sampled_token);
+            }
             break;
         }
         meta_info.generated_tokens++;

--- a/src/common/modules/sampler.cpp
+++ b/src/common/modules/sampler.cpp
@@ -232,7 +232,12 @@ void Sampler::sampler_topk_apply(int k) {
         pairs.begin() + k,
         pairs.end(),
         [](const logits_t& a, const logits_t& b) {
-            return a.logits > b.logits;
+            // bf16 logits tie exactly often enough to matter over a 100k+ vocab,
+            // and partial_sort is not stable, so a bare `>` leaves the winner of a
+            // tie down to the sort's internals. Lowest id wins instead: the order
+            // is then reproducible and matches sample_greedy()'s argmax.
+            if (a.logits != b.logits) { return a.logits > b.logits; }
+            return a.token_id < b.token_id;
         }
     );
 
@@ -347,8 +352,101 @@ void Sampler::ring_buffer_update_sparse(int sampled_index) {
 /// \brief Sample the token
 /// \param x the input buffer
 /// \return the sampled token
+int Sampler::sample_greedy(buffer<bf16>& x) {
+    const bool penalties_active =
+        (this->repeat_last_n != 0) &&
+        (this->rep_penalty != 1.0f || this->freq_penalty != 0.0f || this->pre_penalty != 0.0f);
+
+    float best = -std::numeric_limits<float>::infinity();
+    int best_id = 0;
+
+    if (penalties_active) {
+        // penalties reorder the logits, so they have to land before the argmax.
+        // that needs the fp32 copy, but nothing past it does.
+        #if USEAVX2
+        const int simd_width = 8;
+        int i = 0;
+        for (; i <= in_features - simd_width; i += simd_width) {
+            __m128i bf16_vals_x = _mm_loadu_si128((__m128i*)&x[i]);
+            __m256 fp32_vals_x = bf16o_fp32(bf16_vals_x);
+            _mm256_storeu_ps(&this->logits[i], fp32_vals_x);
+        }
+        for (; i < in_features; i++) {
+            this->logits[i] = x[i];
+        }
+        #else
+        for (int i = 0; i < in_features; i++) {
+            this->logits[i] = x[i];
+        }
+        #endif
+        sampler_penalty_apply_sparse();
+        for (int i = 0; i < in_features; i++) {
+            if (this->logits[i] > best) {
+                best = this->logits[i];
+                best_id = i;
+            }
+        }
+    }
+    else {
+        // Nothing rewrites the logits, so scan them where they lie: no
+        // vocab-sized fp32 buffer is written at all. The logits come back in
+        // device-mapped memory where element-at-a-time reads are punishing, so
+        // the scan pulls 8 at a time and keeps the running argmax in lanes.
+        #if USEAVX2
+        const int simd_width = 8;
+        int i = 0;
+        __m256 vmax = _mm256_set1_ps(-std::numeric_limits<float>::infinity());
+        __m256i vidx = _mm256_set1_epi32(0);
+        __m256i vcur = _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7);
+        const __m256i vstep = _mm256_set1_epi32(simd_width);
+        for (; i <= in_features - simd_width; i += simd_width) {
+            __m256 v = bf16o_fp32(_mm_loadu_si128((__m128i*)&x[i]));
+            __m256 gt = _mm256_cmp_ps(v, vmax, _CMP_GT_OQ);
+            vmax = _mm256_blendv_ps(vmax, v, gt);
+            vidx = _mm256_castps_si256(_mm256_blendv_ps(_mm256_castsi256_ps(vidx),
+                                                        _mm256_castsi256_ps(vcur), gt));
+            vcur = _mm256_add_epi32(vcur, vstep);
+        }
+        alignas(32) float lane_max[simd_width];
+        alignas(32) int lane_idx[simd_width];
+        _mm256_store_ps(lane_max, vmax);
+        _mm256_store_si256((__m256i*)lane_idx, vidx);
+        for (int j = 0; j < simd_width; j++) {
+            // strictly greater keeps the lowest index on a tie, in both loops
+            if (lane_max[j] > best) {
+                best = lane_max[j];
+                best_id = lane_idx[j];
+            }
+        }
+        for (; i < in_features; i++) {
+            float v = x[i];
+            if (v > best) {
+                best = v;
+                best_id = i;
+            }
+        }
+        #else
+        for (int i = 0; i < in_features; i++) {
+            float v = x[i];
+            if (v > best) {
+                best = v;
+                best_id = i;
+            }
+        }
+        #endif
+    }
+
+    // callers that inspect the surviving candidates still get a consistent view
+    this->top_k_logits.assign(1, logits_t{ best, best_id, 1.0f });
+    ring_buffer_update_sparse(best_id);
+    return best_id;
+}
+
 int Sampler::sample(buffer<bf16>& x) {
     // PRNG is seeded once at construction, no per-call seeding needed
+    if (this->top_k == 1) {
+        return sample_greedy(x);
+    }
 
     // COPY FROM `x` → `this->logits[]`
     #if USEAVX2

--- a/src/include/AutoModel/automodel.hpp
+++ b/src/include/AutoModel/automodel.hpp
@@ -147,6 +147,11 @@ protected:
 	std::unique_ptr<npu_xclbin_manager> npu = nullptr;
 	bool enable_preemption = false;
     std::vector<int> checkpoint_his;
+	/// \brief run one more forward on the eos token once a turn ends
+	/// \note this keeps the kv cache aligned with token_history so a following
+	///       turn can append to it. Models that rewind or clear between turns
+	///       throw that state away anyway, so for them it is a wasted step.
+	bool forward_on_eos = true;
 
 
 	uint32_t MAX_L = 0;
@@ -257,6 +262,22 @@ public:
 		time_utils::time_with_unit ttft_in_second = time_utils::cast_to_s(ttft_time);
 		return ttft_in_second.first;
 	}
+
+	/// \brief total time held by one profiler slot, in ms
+	/// \param slot index into profiler_list, see profiler_slot_t
+	float get_profiler_ms(int slot){
+		time_utils::time_with_unit t = this->profiler_list[slot].get_total_time();
+		return time_utils::cast_to_s(t).first * 1000.0f;
+	}
+
+	/// \brief profiler slot ids, so a harness can break a turn down by phase
+	enum profiler_slot_t {
+		SLOT_PREFILL = PREFILL_TIME,
+		SLOT_DECODING = DECODING_TIME,
+		SLOT_SAMPLING = SAMPLING_TIME,
+		SLOT_ENCODE = TKOEN_ENCODE_TIME,
+		SLOT_DECODE = TKOEN_DECODE_TIME,
+	};
 
 	/// \brief Set the topk
 	/// \param topk the topk

--- a/src/include/hrx_cpp/hrx_cpp.hpp
+++ b/src/include/hrx_cpp/hrx_cpp.hpp
@@ -343,6 +343,9 @@ public:
     hrx_executable_t exe_ = nullptr;
     uint32_t ord_ = 0;
     std::vector<hrx_buffer_ref_t> binds_;
+    // set when start() didn't actually get a dispatch onto the stream, so
+    // wait() doesn't synchronize on (and report success for) a no-op.
+    bool dispatch_failed_ = false;
 
     run() = default;
     explicit run(hrx_executable_t exe, uint32_t ord) : exe_(exe), ord_(ord) {}
@@ -352,23 +355,33 @@ public:
     }
 
     // Record the dispatch on the stream (no synchronize); wait() flushes.
-    void start() {
+    // Returns false on failure -- a caller that ignores it still gets a
+    // correct wait(), which now knows nothing was actually dispatched.
+    bool start() {
+        dispatch_failed_ = false;
         if (!exe_) {
             std::fprintf(stderr, "[hrx][ERROR] run::start with null executable\n");
-            return;
+            dispatch_failed_ = true;
+            return false;
         }
         if (binds_.empty()) {
             std::fprintf(stderr, "[hrx][ERROR] run::start with no bindings\n");
-            return;
+            dispatch_failed_ = true;
+            return false;
         }
         hrx_dispatch_config_t cfg = {{1, 1, 1}, {1, 1, 1}, 0};
         hrx_status_t s = hrx_stream_dispatch(rt().stream, exe_, ord_, &cfg,
                                              nullptr, 0, binds_.data(),
                                              binds_.size(), HRX_DISPATCH_FLAG_NONE);
-        hrx_report(s, "run::start hrx_stream_dispatch");
+        if (hrx_report(s, "run::start hrx_stream_dispatch")) {
+            dispatch_failed_ = true;
+            return false;
+        }
+        return true;
     }
 
     ert_cmd_state wait() {
+        if (dispatch_failed_) return ERT_CMD_STATE_ERROR;
         hrx_status_t s = hrx_stream_synchronize(rt().stream);
         return hrx_report(s, "run::wait hrx_stream_synchronize")
                    ? ERT_CMD_STATE_ERROR
@@ -379,20 +392,29 @@ public:
 class runlist {
 public:
     std::vector<run> runs_;
+    // true if any run in the list failed to dispatch.
+    bool dispatch_failed_ = false;
 
     runlist() = default;
     explicit runlist(const hw_context& /*ctx*/) {}
 
     void add(const run& r) { runs_.push_back(r); }
     void add(run&& r) { runs_.push_back(std::move(r)); }
-    void reset() { runs_.clear(); }
+    void reset() {
+        runs_.clear();
+        dispatch_failed_ = false;
+    }
 
     // Record every dispatch (no per-run synchronize) so HRX submits them as a
     // batch; wait() runs one synchronize for the whole list.
     void execute() {
-        for (auto& r : runs_) r.start();
+        dispatch_failed_ = false;
+        for (auto& r : runs_) {
+            if (!r.start()) dispatch_failed_ = true;
+        }
     }
     ert_cmd_state wait() {
+        if (dispatch_failed_) return ERT_CMD_STATE_ERROR;
         hrx_status_t s = hrx_stream_synchronize(rt().stream);
         return hrx_report(s, "runlist::wait hrx_stream_synchronize")
                    ? ERT_CMD_STATE_ERROR

--- a/src/include/modules/sampler.hpp
+++ b/src/include/modules/sampler.hpp
@@ -94,6 +94,16 @@ public:
     void sampler_penalty_apply();
     void sampler_penalty_apply_sparse();
     
+    /// \brief argmax shortcut taken when top_k == 1
+    /// \param x the raw logits
+    /// \return the winning token id
+    /// \note softmax, top-p, min-p and temperature are all order preserving, so
+    ///       with k == 1 the winner is just the argmax of the (penalised) logits.
+    ///       Going through the general path would allocate and partial_sort a
+    ///       vocab-sized array of triples and run three full-vocab softmaxes for
+    ///       a result that never depends on any of it.
+    int sample_greedy(buffer<bf16>& x);
+
     void sampler_topk_apply(int k);
     void sampler_topp_apply(float p);
     void sampler_minp_apply(float p);


### PR DESCRIPTION
Fixes #15. Three changes, all from upstream FastFlowLM.

**Sampling does far less work per token.** When the sampler is set to always
take the single most likely token — the usual setting when you want
repeatable output — it was still doing all the work random sampling needs:
copying the entire vocabulary into a wider number format, sorting it, and
running three passes over it to turn scores into probabilities. None of that
can change which token ends up on top. It now just scans for the largest
score and returns it, reading the numbers where they already sit instead of
copying them first.

A correctness fix comes with it. Two tokens land on exactly the same score
more often than you'd expect at this precision, and the old code let the
sort pick the winner — sorts make no promise about that, so two builds could
disagree. Ties now always go to the lower-numbered token.

**A prefill length of zero no longer causes undefined behavior.** Prefill is
the pass over your prompt before generation starts; long prompts get split
into chunks. The chunk size was rounded up to a power of two using a
logarithm, which means nothing on zero or a negative number, so an unset
limit produced whatever the compiler felt like that day. It's now guarded,
and an unset limit means "don't chunk" — which is what the code just below
it already assumed.

Two small additions for our own benchmarking ride along, neither changing
current behavior: a model can skip a redundant forward pass at end of turn
if it throws that state away anyway, and a caller can read how long each
phase took instead of only time-to-first-token.

**Failed NPU submissions on the HRX backend now stop instead of being
logged and ignored.** A failed submission used to print an error and carry
on as though it had worked, so the wait afterwards reported success.
Upstream's fix for this leans on API changes we don't have, so this is the
same idea written against what's actually here. We don't build this backend
by default, so nothing changes today.

**Checked on hardware.** Built clean and ran against the NPU: the LLM test
suite passes, and I called the server directly with the take-the-top-token
setting to be sure the new fast path is the one being exercised. Coherent
output, no crashes.

Two things worth flagging:

The issue says this speeds up the open Qwen3.6 engine. That engine doesn't
use this sampler at all — it has its own. The change still sits on the hot
path for every model that goes through `AutoModel`.

Separately, two identical requests don't return identical text even on the
take-the-top-token setting. That isn't from this change — an older build of
this project does the same thing, and the new code is a plain search for a
maximum with no randomness in it. Someone should look into it on its own
sometime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
