### PR TITLE
Open engine: read Q4_K containers, and write them (#17)

### DIFF
--- a/open_kernels/model/q4nx.py
+++ b/open_kernels/model/q4nx.py
@@ -18,10 +18,11 @@ The chunk format is PER TENSOR. The stock Qwen3.6-35B keeps only its lm_head at
 q8; its fine-tunes (Darwin, Grug, BigBang, Aquila-mini, Ornith 1.5, and
 Atomic-Germ's own NPU2 mirror) pack attention, linear-attention and shared-expert
 projections at q8 and only the routed experts at q4_1; Qwen3.5 dense containers
-store `ssm_out_proj` and alpha / beta at q8. So nothing is refused at open: each
-tensor is classified from its own shape, and `dq_tile` reads either format. A
-chunk size that is neither 5120 nor 8704 is refused when that tensor is read,
-naming it (Q4_K is 4736; 1280 / 2560 are a smaller chunk geometry).
+store `ssm_out_proj` and alpha / beta at q8; a container written by FLM 1.0.3+
+holds Q4_K (4736 B, `dq_chunks_q4_k`). So nothing is refused at open: each tensor
+is classified from its own shape, and `dq_tile` reads all three. A chunk size that
+is none of them is refused when that tensor is read, naming it (1280 / 2560 are a
+smaller chunk geometry).
 
 Which reading a q8 tensor gets is the packer's decision, mirrored here so a slice
 comparison always measures the KERNELS and never the weights:
@@ -29,8 +30,10 @@ comparison always measures the KERNELS and never the weights:
   * `native_q8(name)` -- true for the projections this kernel set streams at q8
     (the plan's `q8_perm` ops, OPEN-QUANT-Q8). Those read as the container's own
     q8 values, because that is exactly what the pool holds.
-  * `requant_q8` (default True) -- every other q8 tensor reads as the q4_1 the
-    packer writes for it (the re-quantising fallback, OPEN-PACK-PLAN).
+  * `requant_q8` (default True) -- every other q8 tensor, and every Q4_K tensor,
+    reads as the q4_1 the packer writes for it (the re-quantising fallback and the
+    Q4_K transcode, OPEN-PACK-PLAN / OPEN-QUANT-Q4K). Turning it off reads the
+    container's own values, and for Q4_K that difference IS the transcode's cost.
 
 `make_decode.py --requant` forces the whole run -- spec, plan, pools and this
 reader -- onto the fallback, which is the A/B against the q8 path.
@@ -47,18 +50,29 @@ import numpy as np
 
 CHUNK_Q4 = 5120
 CHUNK_Q8 = 8704
+CHUNK_Q4K = 4736
 
 
-def _requant_q4_1(chunks):
-    """recipes.pack's q8 -> q4_1 (the packer's own arithmetic; one implementation, not two)."""
+def _pack_fn(name):
+    """A function out of recipes.pack -- the packer's own arithmetic, one implementation."""
     try:
-        from recipes.pack import requant_q4_1
+        import recipes.pack as p
     except ImportError:
         import pathlib
         import sys
         sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
-        from recipes.pack import requant_q4_1
-    return requant_q4_1(chunks)
+        import recipes.pack as p
+    return getattr(p, name)
+
+
+def _requant_q4_1(chunks):
+    """recipes.pack's q8 -> q4_1."""
+    return _pack_fn("requant_q4_1")(chunks)
+
+
+def _q4k_to_q4_1(chunks):
+    """recipes.pack's Q4_K -> q4_1."""
+    return _pack_fn("q4k_to_q4_1")(chunks)
 
 
 def bf16_to_f32(u16):
@@ -107,6 +121,37 @@ def dq_chunks_q8(chunks):
     return q[:, p].reshape(nch, 32, 8, 32).astype(np.float32) * d[:, j].reshape(nch, 32, 8, 32)
 
 
+def dq_chunks_q4_k(chunks):
+    """[n, 4736] raw Q4_K chunk bytes -> [n, 32, 8, 32] f32 (row, block, lane).
+
+    The container's own values, with no bf16 collapse: `q4k_block_t` from the FLM 1.0.3
+    decoding kernels holds the same 32-row x 256-K tile a q4_1 chunk does, with a uint8
+    scale and a uint8 min per (32-column group, row) -- index `g*32 + r`, the q4_1 index --
+    against one bf16 pair `(S, M)` per row, `M` already negated:
+
+        scales[8][32] uint8 @ [0, 256)      mins[8][32] uint8 @ [256, 512)
+        qs[256][16]         @ [512, 4608)   byte k*16 + r/2, even row in the low nibble
+        S[32] bf16          @ [4608, 4672)  M[32] bf16 @ [4672, 4736)
+        value(r, k) = S[r] * scales[k/32][r] * nib + M[r] * mins[k/32][r]
+
+    The pool cannot hold that pair separately, so recipes.pack.q4k_to_q4_1 folds it into
+    the pool's bf16 `d` and `m`; reading a container BOTH ways is what measures the cost
+    of doing so (`dq_tile(..., requant=False)`)."""
+    chunks = np.asarray(chunks, np.uint8).reshape(-1, CHUNK_Q4K)
+    nch = chunks.shape[0]
+    scales = chunks[:, :256].astype(np.float32).reshape(nch, 8, 32)                   # [n, g, r]
+    mins = chunks[:, 256:512].astype(np.float32).reshape(nch, 8, 32)
+    S = bf16_to_f32(np.ascontiguousarray(chunks[:, 4608:4672]).view(np.uint16))       # [n, r]
+    M = bf16_to_f32(np.ascontiguousarray(chunks[:, 4672:4736]).view(np.uint16))
+    qs = chunks[:, 512:4608].reshape(nch, 256, 16)                                    # [n, k, r//2]
+    r = np.arange(32)
+    nib = np.where(r % 2 == 0, qs[:, :, r // 2] & 0xF, qs[:, :, r // 2] >> 4)         # [n, k, r]
+    nib = nib.astype(np.float32).transpose(0, 2, 1).reshape(nch, 32, 8, 32)           # [n, r, g, i]
+    d = S[:, :, None] * scales.transpose(0, 2, 1)                                     # [n, r, g]
+    m = M[:, :, None] * mins.transpose(0, 2, 1)
+    return nib * d[..., None] + m[..., None]
+
+
 class Q4NX:
     def __init__(self, path):
         self.path = str(path)
@@ -131,11 +176,11 @@ class Q4NX:
         return t["shape"][-1] if t.get("dtype") == "I8" and t.get("shape") else 0
 
     def _refuse(self, name, cb):
-        guess = ("Q4_K (FLM 1.0.3), which needs a different dequant" if cb == 4736 else
-                 f"a smaller chunk geometry ({cb * 8192 // CHUNK_Q4} values per chunk instead of 8192)"
+        guess = (f"a smaller chunk geometry ({cb * 8192 // CHUNK_Q4} values per chunk instead of 8192)"
                  if cb in (1280, 2560) else "not a chunk format this reader knows")
         raise RuntimeError(f"{self.path}: {name} has {cb}-byte quant chunks; this reader handles "
-                           f"{CHUNK_Q4} (q4_1) and {CHUNK_Q8} (q8) only -- {cb} is {guess}")
+                           f"{CHUNK_Q4} (q4_1), {CHUNK_Q8} (q8) and {CHUNK_Q4K} (Q4_K) only "
+                           f"-- {cb} is {guess}")
 
     def raw(self, name):
         o0, o1 = self.tensors[name]["data_offsets"]
@@ -159,8 +204,8 @@ class Q4NX:
     def dq_tile(self, raw_bytes, out_dim, in_dim, chunk=CHUNK_Q4, requant=None):
         """Raw chunk bytes -> [out, in] f32, in the file's raster order.
 
-        `chunk` is the format those bytes are in. A q8 tensor reads as the packer's q4_1
-        when `requant` (the default: the values the NPU holds), else as its own q8."""
+        `chunk` is the format those bytes are in. A q8 or Q4_K tensor reads as the packer's
+        q4_1 when `requant` (the default: the values the NPU holds), else as its own."""
         if requant is None:
             requant = self.requant_q8
         b = np.frombuffer(raw_bytes, dtype=np.uint8)
@@ -170,6 +215,10 @@ class Q4NX:
             w = dq_chunks_q4_1(_requant_q4_1(b.reshape(-1, CHUNK_Q8)))
         elif chunk == CHUNK_Q8:
             w = dq_chunks_q8(b)
+        elif chunk == CHUNK_Q4K and requant:
+            w = dq_chunks_q4_1(_q4k_to_q4_1(b.reshape(-1, CHUNK_Q4K)))
+        elif chunk == CHUNK_Q4K:
+            w = dq_chunks_q4_k(b)
         else:
             self._refuse("<raw bytes>", chunk)
         w = w.reshape(-1, 32, 256)
@@ -181,7 +230,7 @@ class Q4NX:
 
     def matmul_w(self, name, out_dim, in_dim):
         cb = self.chunk_bytes_of(name)
-        if cb not in (CHUNK_Q4, CHUNK_Q8):
+        if cb not in (CHUNK_Q4, CHUNK_Q8, CHUNK_Q4K):
             self._refuse(name, cb)
         return self.dq_tile(self.raw(name), out_dim, in_dim, cb, self.requant_of(name))
 
@@ -189,7 +238,7 @@ class Q4NX:
         """One expert's `kind` ('up' | 'gate' | 'down') matrix, dequantized."""
         name = f"model.layer.{layer}.mlp.{kind}_exps_proj.weight"
         cb = self.chunk_bytes_of(name)
-        if cb not in (CHUNK_Q4, CHUNK_Q8):
+        if cb not in (CHUNK_Q4, CHUNK_Q8, CHUNK_Q4K):
             self._refuse(name, cb)
         stride = 128 * cb
         b = np.frombuffer(self.raw(name), dtype=np.uint8)

--- a/open_kernels/recipes/pack.py
+++ b/open_kernels/recipes/pack.py
@@ -11,7 +11,7 @@ the same interpreter in C++.
 The container object needs one method: `raw(name) -> bytes-like` (the
 tensor's bytes as stored, in the file's raster order). It may also offer
 `chunk_bytes_of(name) -> int`, the quantized chunk size that tensor is stored in
-(5120 = q4_1, 8704 = q8); a container that cannot say is read as q4_1.
+(5120 = q4_1, 8704 = q8, 4736 = Q4_K); a container that cannot say is read as q4_1.
 
   std_perm        standard [out, in] matmul tensor -> pool band order (64-row bands, K/128 chunks)
   q8_perm         the same tensor kept at q8: 16-row half-tiles of its chunks, in the q8 band
@@ -29,14 +29,16 @@ as 16-row half-tiles the main cores' `gemv_q8_half` consumes. `q8_perm` refuses 
 that is not q8, naming the tensor: that is the check that a container agrees with the
 kernel set it is being packed for.
 
-**q8 sources.** The three chunk ops above (std_perm, expert_stripes, expert_down)
+**Source forms.** The three chunk ops above (std_perm, expert_stripes, expert_down)
 accept a q8 tensor transparently and re-quantize it to q4_1 chunk by chunk on the
-way into the pool (`requant_q4_1`). A q8 chunk and a q4_1 chunk hold the SAME
-32-row x 256-column tile, so no chunk index law changes and neither the plan, the
-manifest nor the kernels know the difference. That is what lets the Qwen3.6-35B
-fine-tunes -- q8 attention, linear-attention and shared experts, q4_1 routed
-experts -- and Qwen3.5's q8 `ssm_out_proj` run on a q4_1-only GEMV. Any other
-chunk size is refused, naming the tensor (OPEN-PACK-PLAN).
+way into the pool (`requant_q4_1`), and a Q4_K tensor -- what FLM 1.0.3+ writes --
+by transcoding it (`q4k_to_q4_1`). All three forms hold the SAME 32-row x
+256-column tile, so no chunk index law changes and neither the plan, the manifest
+nor the kernels know the difference. That is what lets the Qwen3.6-35B fine-tunes
+-- q8 attention, linear-attention and shared experts, q4_1 routed experts -- and
+Qwen3.5's q8 `ssm_out_proj` run on a q4_1-only GEMV, and a 1.0.3 container run at
+all (OPEN-QUANT-Q4K). Any other chunk size is refused, naming the tensor
+(OPEN-PACK-PLAN).
 """
 from __future__ import annotations
 
@@ -44,6 +46,7 @@ import numpy as np
 
 CH = 5120
 Q8 = 8704            # a q8 chunk: 256 bf16 scales then 8192 int8 codes
+Q4K = 4736           # a Q4_K chunk (FLM 1.0.3+): uint8 scales/mins, nibbles, one bf16 (S, M) per row
 BLOCK = 32           # values per quantisation block, along the input dim
 NBLOCK = 8           # 32-blocks per chunk (8192 values = 32 rows x 256 K)
 
@@ -76,6 +79,14 @@ def _bf16_ceil(x) -> np.ndarray:
     """f32 -> bf16 rounded toward +inf."""
     u = np.ascontiguousarray(x, np.float32).view(np.uint32)
     return np.where(u >> 31, u >> 16, (u + 0xFFFF) >> 16).astype(np.uint16)
+
+
+def _bf16_rne(x) -> np.ndarray:
+    """f32 -> bf16, round to nearest even. The directed roundings above exist to make a
+    re-quantized block's range cover its source; a Q4_K scale is not a range end, it is a
+    value being re-expressed, so it takes the nearest bf16."""
+    u = np.ascontiguousarray(x, np.float32).view(np.uint32)
+    return ((u + 0x7FFF + ((u >> 16) & 1)) >> 16).astype(np.uint16)
 
 
 def requant_q4_1(chunks) -> np.ndarray:
@@ -117,6 +128,47 @@ def requant_q4_1(chunks) -> np.ndarray:
     flat = np.zeros((n, 8192), np.uint8)
     flat[:, _CODE_IDX] = nib.reshape(n, -1)
     out[:, 1024:] = flat[:, 0::2] | (flat[:, 1::2] << 4)
+    return out
+
+
+def q4k_to_q4_1(chunks) -> np.ndarray:
+    """[n, 4736] Q4_K chunk bytes -> [n, 5120] q4_1 chunk bytes, in the same chunk order.
+
+    Both formats hold a 32-row x 256-column tile with one (scale, min) pair per (row,
+    32-column group), indexed `g*32 + r` in both, so nothing is re-quantized and no index
+    law moves. The Q4_K chunk (`q4k_block_t` in the FLM 1.0.3 decoding kernels) is
+
+        scales[8][32] uint8 @ [0, 256)      mins[8][32] uint8 @ [256, 512)
+        qs[256][16]         @ [512, 4608)   byte k*16 + r/2, even row in the low nibble
+        S[32] bf16          @ [4608, 4672)  M[32] bf16 @ [4672, 4736), M already negated
+
+    and reads as `S[r] * scales[g][r] * nib + M[r] * mins[g][r]`. That is the pool's
+    `nib*d + m` with `d = S*scales` and `m = M*mins`, so the transcode is:
+
+      * the two products, rounded to bf16 -- the one place values move. The exact product
+        of a bf16 and a uint8 needs 16 significand bits and the pool holds 8, so each
+        group's scale shifts by at most a half-ulp of bf16, 2^-8 relative. Nothing else
+        is lost;
+      * a byte de-interleave of the nibbles. Q4_K keeps a column's 32 rows in 16
+        contiguous bytes; the pool splits rows 0-15 and 16-31 into two 2048-byte planes,
+        so q4_1 byte `h*2048 + k*8 + j` is Q4_K byte `k*16 + h*8 + j`. The nibble values
+        and their parity are unchanged.
+
+    src/open_qwen36/pools.cpp does the same in float and must agree byte for byte
+    (specs/open-engine/tests/test_quant_q4k.py and pools_test.cpp hash the same vectors).
+    """
+    src = _u8(chunks).reshape(-1, Q4K)
+    n = src.shape[0]
+    S = _bf16_to_f32(np.ascontiguousarray(src[:, 4608:4672]).view(np.uint16))     # [n, 32] per row
+    M = _bf16_to_f32(np.ascontiguousarray(src[:, 4672:4736]).view(np.uint16))     # [n, 32] per row
+    row = np.arange(256) % BLOCK                                                  # meta slot g*32 + r
+    d = (S[:, row] * src[:, :256].astype(np.float32)).astype(np.float32)
+    m = (M[:, row] * src[:, 256:512].astype(np.float32)).astype(np.float32)
+    out = np.empty((n, CH), np.uint8)
+    out[:, :512] = _bf16_rne(d).view(np.uint8).reshape(n, 512)
+    out[:, 512:1024] = _bf16_rne(m).view(np.uint8).reshape(n, 512)
+    qs = src[:, 512:4608].reshape(n, 256, 2, 8)                                   # [k, half, j]
+    out[:, 1024:] = qs.transpose(0, 2, 1, 3).reshape(n, CH - 1024)
     return out
 
 
@@ -214,8 +266,6 @@ def _u8(b) -> np.ndarray:
 
 
 def _chunk_guess(ch: int) -> str:
-    if ch == 4736:
-        return "Q4_K (FLM 1.0.3), which needs a different dequant"
     if ch in (1280, 2560):
         return f"a smaller chunk geometry ({ch * 8192 // CH} values per chunk instead of 8192)"
     return "not a chunk format this packer knows"
@@ -224,23 +274,25 @@ def _chunk_guess(ch: int) -> str:
 def q4_chunks_of(m, name: str, raw, c0: int = 0, n: int | None = None) -> np.ndarray:
     """Chunks [c0, c0 + n) of `raw` as [n, 5120] q4_1 bytes, whatever the container stores.
 
-    q4_1 is a view; q8 (8704 B chunks) is re-quantized here, in batches so a 2048-chunk
-    projection does not build a 70 MB float array. Anything else is refused by name, byte
-    count and what the count probably means -- the message someone reads when they point
-    the engine at a container this packer cannot use."""
+    q4_1 is a view; q8 (8704 B chunks) is re-quantized here and Q4_K (4736 B chunks) is
+    transcoded, both in batches so a 2048-chunk projection does not build a 70 MB float
+    array. Anything else is refused by name, byte count and what the count probably means
+    -- the message someone reads when they point the engine at a container this packer
+    cannot use."""
     b = _u8(raw)
     get = getattr(m, "chunk_bytes_of", None)
     ch = (get(name) if callable(get) else 0) or CH
-    if ch not in (CH, Q8):
-        raise ValueError(f"{name}: {ch}-byte quant chunks; the packer reads {CH} (q4_1) and {Q8} (q8) "
-                         f"only -- {ch} is {_chunk_guess(ch)}")
+    if ch not in (CH, Q8, Q4K):
+        raise ValueError(f"{name}: {ch}-byte quant chunks; the packer reads {CH} (q4_1), {Q8} (q8) "
+                         f"and {Q4K} (Q4_K) only -- {ch} is {_chunk_guess(ch)}")
     src = b.reshape(-1, ch)
     sel = src[c0:] if n is None else src[c0:c0 + n]
     if ch == CH:
         return sel
+    conv = requant_q4_1 if ch == Q8 else q4k_to_q4_1
     out = np.empty((sel.shape[0], CH), np.uint8)
     for i in range(0, sel.shape[0], 256):
-        out[i:i + 256] = requant_q4_1(sel[i:i + 256])
+        out[i:i + 256] = conv(sel[i:i + 256])
     return out
 
 

--- a/specs/open-engine/plans/archive/q4k-containers.md
+++ b/specs/open-engine/plans/archive/q4k-containers.md
@@ -1,0 +1,204 @@
+# Plan: read Q4_K containers, and teach the converter to write them
+
+**Status:** IMPLEMENTED 2026-09-08, merged into `spec.md` as `OPEN-QUANT-Q4K`.
+Steps 1-5 done and green (13 unit tests either side of the NumPy / C++ line); step 6
+done for the small model through the standalone engine, still open for `flm serve` /
+`flm-test` and the 27B's native-Q4_K source. Unblocks Phases 1-4 of
+`.claude/plans/open-engine-both-quants-and-distribution.md`, and corrects that
+plan on two points (see below).
+
+**Spec impact:** one new requirement, `OPEN-QUANT-Q4K`. `OPEN-PACK-PLAN` gains a
+paragraph -- Q4_K joins q8 as a source form the three q4 chunk ops accept. No
+existing requirement changes behaviour, and the frozen q4_1 pool bytes must stay
+byte-equal. **No kernel change, no new kernel point, no build-key movement.**
+
+## What changed since that plan was written
+
+Two things, and both make this smaller than it looked.
+
+**The 4736-byte layout is no longer unknown.** The both-quants plan says "32
+rows x 144 = 4608 -- 128 B short of 4736, and I don't yet know what they are.
+Pinning that down is step 1." It is pinned. ROCm merged `_pack_q4k` into
+`FLM_Q4NX_Converter` main -- the upstream of `utilities/q4nx-build` -- and its
+docstring gives `q4k_block_t` from the FLM 1.0.3 decoding kernels'
+`model_spec.h` field for field. The missing 128 bytes are two bf16 per-row
+super-block values, `S` and `M`, 64 bytes each. There is no llama.cpp
+`block_q4_K` in the file at all: the 12 packed 6-bit bytes are expanded to 8 + 8
+plain uint8, and the fp16 `d` / `dmin` are re-fitted to bf16.
+
+**The kernel does not have to learn anything.** That plan's Phase 3 assumed a
+Q4_K variant of the chunk loader in `gemv_q4.h`, with the 16 KB program memory
+as the risk. It is not needed. Q4_K's effective per-group scale and min have
+*exactly* the granularity the pool's q4_1 chunk already has -- one pair per
+(row, 32-column group), 8 groups x 32 rows per chunk, the same 256-entry index
+-- so a Q4_K chunk becomes a q4_1 pool chunk with two multiplies per entry and
+one byte de-interleave. That puts this on the seam the q8 work already built
+(`OPEN-PACK-PLAN`, "q8 sources"): the packer is the only place that knows.
+
+## The format, concretely
+
+One `q4k_block_t` per 32-row x 256-column chunk, everything column-major over
+the chunk. 4736 B = 256 + 256 + 4096 + 64 + 64:
+
+| field | bytes | index | note |
+|---|---|---|---|
+| `scales` uint8[8][32] | 0 : 256 | `g*32 + r` | per (32-column group, row) |
+| `mins` uint8[8][32] | 256 : 512 | `g*32 + r` | same |
+| `qs` uint4[256][16] | 512 : 4608 | byte `k*16 + r/2` | even row = low nibble |
+| `S` bf16[32] | 4608 : 4672 | `r` | one super-block per chunk |
+| `M` bf16[32] | 4672 : 4736 | `r` | **stored negated** |
+
+Value: `w[r][k] = S[r] * scales[g*32+r] * q + M[r] * mins[g*32+r]`, `g = k/32`.
+GGUF's Q4_K subtracts its min; the FLM kernel adds both accumulators, so the
+converter negates `M` on the way out and the reading above is a plain add.
+
+The pool's q4_1 chunk is `d[256] bf16 | m[256] bf16 | 4096 nibble bytes`, `d`
+and `m` indexed `g*32 + r`, nibble `(r/16)*4096 + k*16 + (r%16)`, read as
+`nib*d + m` (`designs/gemv_q4/gemv_q4.h:12-18`). So the transcode is:
+
+- `d[i] = bf16(S[i%32] * scales[i])` and `m[i] = bf16(M[i%32] * mins[i])` for
+  `i < 256` -- the scale index is already identical, no permutation;
+- nibbles: `q4_1[h*2048 + k*8 + j] = q4k[k*16 + h*8 + j]` for `h` in {0,1},
+  `j < 8`. Q4_K keeps a column's 32 rows in 16 contiguous bytes; q4_1 splits
+  rows 0-15 and 16-31 into two 2048-byte planes. In NumPy,
+  `qs.reshape(256, 2, 8).transpose(1, 0, 2)`. The nibble values are unchanged:
+  both formats hold unsigned uint4 against a (scale, min) pair, and both pair
+  rows `(2b, 2b+1)` into a byte with the even row in the low nibble.
+
+### What it costs
+
+One thing, and it should be measured rather than argued: `S` is bf16 and
+`scales` is uint8, so the exact product carries about 16 significant bits and
+the pool holds 8. Collapsing it rounds each group's scale by at most a half-ulp
+of bf16 -- `2^-8`, 0.39% relative -- correlated across that group's 32 weights.
+
+For scale, against something already measured: the q8 -> q4_1 re-quantization
+the packer does today costs 8% weight RMS and still scored 0.999682 logits
+correlation on a 4-layer slice. 0.4% is twenty times smaller and should sit well
+above the 0.99999 bar every family is held to -- but "should" is why the
+acceptance criteria name a number against a Q4_K-faithful fp64 reference.
+
+If that number ever disappoints, the fallback is the original Phase 3: a Q4_K
+chunk loader in `gemv_q4.h` keeping `S` and `scales` separate. It buys back 8
+bits of scale precision and costs a kernel design against 16 KB of program
+memory. Not first.
+
+## New requirement
+
+### OPEN-QUANT-Q4K: the packers read Q4_K chunks
+**Applies to:** openflowlm-next (`open_kernels/model/q4nx.py`,
+`open_kernels/recipes/pack.py`, `src/open_qwen36/pools.cpp`,
+`utilities/q4nx-build/q4nx/{gguf_tensor,model_converter}.py`)
+**Test category:** unit (the transcode, both packers, the reference) + manual
+(the hardware run: needs the NPU and a Q4_K container)
+
+A tensor stored in 4736-byte Q4_K chunks shall be accepted by the three q4 chunk
+ops (`std_perm`, `expert_stripes`, `expert_down`) and converted to the pool's
+q4_1 chunk on the way in, exactly as a q8 source is. A Q4_K chunk and a q4_1
+chunk hold the same 32-row x 256-column tile, so no chunk index law, plan,
+manifest, kernel or build key changes. `q8_perm` continues to demand q8: a
+kernel set built to stream a projection at q8 is not satisfied by Q4_K.
+
+`utilities/q4nx-build` shall additionally be able to *write* Q4_K, because FLM
+1.0.3+ requires it for the 35B MoE projections -- packing those as q4_1 gives
+infinite `////` decoding or SIGSEGV in the closed runtime, so this is not a
+preference.
+
+**Acceptance criteria:**
+- A synthetic Q4_K chunk (random bf16 `S` / `M`, random uint8 scales and mins,
+  random nibbles) transcoded to q4_1 and read back as `nib*d + m` equals
+  `S*scales*q + M*mins` computed in f64 from the same bytes, every value within
+  `2^-8 * (|S*scales*q| + |M*mins|)` and no more.
+- The nibble de-interleave is exact: for every `(r, k)`, the uint4 read out of
+  the q4_1 chunk at nibble `(r/16)*4096 + k*16 + (r%16)` equals the one read out
+  of the Q4_K chunk at byte `k*16 + r/2`, nibble `r%2`.
+- NumPy and C++ agree: both build the same synthetic Q4_K chunks, transcode, and
+  assert the same FNV-1a (`tests/test_quant_q4k.py`,
+  `src/open_qwen36/pools_test.cpp`).
+- A Q4_K tensor put through `std_perm` lands at the same pool chunk positions a
+  q4_1 tensor of the same shape does: the permutation is applied to transcoded
+  chunks, exactly as it is to file chunks.
+- `q8_perm` over a Q4_K tensor is refused naming the tensor and both byte
+  counts. A chunk width that is none of 5120 / 8704 / 4736 is still refused,
+  naming the width and what it probably is.
+- The frozen q4_1 pools of `OPEN-PACK-PLAN` are byte-identical before and after
+  (`tests/test_pack_plan.py` passes unmodified).
+- `model/q4nx.py`'s `dq_tile` on a Q4_K tensor reads the transcoded q4_1 the NPU
+  actually holds by default -- the convention q8 already follows, so a slice
+  comparison measures the kernels -- and the container's own Q4_K values under
+  `requant=False`, which is the transcode's own quality number.
+- Writer and reader agree: a tensor packed by `_pack_q4k` from known float input
+  and read back by `dq_chunks_q4_k` recovers the input to the Q4_K grid.
+- **Manual:** a Q4_K container built by `q4nx-build` for a validated shape scores
+  >= 0.99999 logits correlation with the same argmax and top-5 against the fp64
+  replica reading the container's own Q4_K values, then passes
+  `utilities/flm-test --llm` through `flm serve`.
+
+## Changes
+
+| file | change |
+|---|---|
+| `open_kernels/model/q4nx.py` | `CHUNK_Q4K = 4736`; `dq_chunks_q4_k` (the f64 reference dequant); `q4k_to_q4_1` (the transcode); a `dq_tile` branch; drop 4736 from `_refuse`'s guess list. |
+| `open_kernels/recipes/pack.py` | share `q4k_to_q4_1`; `q4_chunks_of` accepts 4736 alongside 8704, batched the same way; `_chunk_guess` drops 4736. |
+| `src/open_qwen36/pools.hpp/.cpp` | `Q4K_CHUNK = 4736`; `q4k_to_q4_1_chunks` beside `requant_q4_1_chunks`; `q4_source` accepts it; `chunk_guess` drops 4736. |
+| `src/open_qwen36/pools_test.cpp` | the C++ half of the agreement test. |
+| `utilities/q4nx-build/q4nx/gguf_tensor.py` | port `_refit_one_side` and `unpack_q4_k` from ROCm main; route `Q4_K` to the native path instead of dequantize-then-requantize (upstream measures that at 0.240 bits of ENOB and 0.375 bpw worse, with most of the damage in the tail). |
+| `utilities/q4nx-build/q4nx/model_converter.py` | port `_pack_q4k`; add `Q4_K` to `default_tensor_type` and `get_ggml_type`; dispatch in `_pack`. Bring the two fixes that ride with it: `_requantize_to` on 3D expert weights, and the tied-embedding fix for Qwen3.5 4B. |
+| `utilities/q4nx-build/configs/*.json` | `default_tensor_type: Q4_K` where FLM 1.0.3+ requires it (35B MoE projections first); leave everything else where it is. |
+| `specs/open-engine/spec.md` | `OPEN-QUANT-Q4K`; a Q4_K sentence in `OPEN-PACK-PLAN`'s "q8 sources" paragraph, which becomes "source forms". |
+| `specs/open-engine/tests/test_quant_q4k.py` | new: the unit criteria above. |
+| `src/open_qwen36/README.md` | both formats, one paragraph near the top -- after it is true. |
+
+Roughly 150 lines of engine and packer code, plus the converter port: four
+functions, a targeted merge. Our copy is Atomic-Germ's fork plus local work and
+has diverged from ROCm main across the whole file -- do not re-sync it.
+
+## Order (TDD)
+
+1. `tests/test_quant_q4k.py` -- write the unit criteria, confirm they fail for
+   the right reason (no `dq_chunks_q4_k`, no 4736 branch), not on a stub.
+2. `model/q4nx.py`: reference dequant + transcode. The Python criteria go green.
+3. `recipes/pack.py`: accept the source. `test_pack_plan.py` must still pass
+   untouched.
+4. `pools.cpp` + `pools_test.cpp`. The FNV-1a agreement goes green.
+5. Converter port; the writer/reader round trip goes green.
+6. Build real Q4_K containers and validate (below).
+7. Spec, README, archive this plan.
+
+## Validating without a shipped Q4_K container
+
+There isn't one anywhere yet. Every container this repo has read is q4_1, q4_0,
+q8 or a smaller geometry -- 31 local models scanned plus the 68-container HF
+census in `.claude/plans/open-kernel-model-priority.md`; zero at 4736.
+Atomic-Germ said on ROCm issue #21 that he would merge the Q4_K converter "and
+then start updating some models on my huggingface", so shipped ones are coming.
+They are not here.
+
+So step 6 builds them, and the source is already on disk:
+
+- **Fast loop: Qwen3.5-0.8B.** `qwen3.5-0.8b-condB-q8.gguf` (812 MB, in
+  `.lmstudio`), converted with `default_tensor_type: Q4_K`. Shape row 8, already
+  validated, 18.5 tok/s here. Exercises the re-quantize-into-Q4_K path.
+- **The real one: Qwen3.6-27B-A2.8B.** `qwen36-27b-a2.8b-mtp-Q4KM.gguf` (16.5 GB)
+  sits next to the q4_1 `model.q4nx` that was built *from that same GGUF* and is
+  the validated 27B MoE. Converting it again at Q4_K gives an A/B on identical
+  weights: same source, two containers, one kernel set, and the only difference
+  is the format. That is the strongest check available, and it needs no
+  download. Budget ~17 GB of free disk for the second container.
+
+The honest limit: our reader is checked against our writer, both derived from
+the same upstream source. If FLM 1.0.4 moved the struct again, this catches
+nothing. What it does guarantee is that a mismatch shows up as a **refusal
+naming the width**, never as silently wrong weights -- the reader dispatches on
+chunk width and knows exactly three.
+
+## Not in scope
+
+- A Q4_K-native GEMV (the precision fallback above).
+- GGUF as a runtime source. It shares this dequant and gets cheaper once this
+  lands, but it is a separate path -- issue #14.
+- q4_0 containers (`container-formats.md`, still proposed) and the 1280 / 2560
+  geometries. Different problems that happen to live at the same seam.
+- Phases 5-8 of the both-quants plan: family-keyed kernel sets in `flm-add`,
+  release distribution, `flm-test` coverage of the dense families. This plan is
+  the reader and the writer, nothing else.

--- a/specs/open-engine/spec.md
+++ b/specs/open-engine/spec.md
@@ -242,7 +242,7 @@ counts POOL half-tiles; `chunk0` counts SOURCE file chunks, as it does for
 refused naming the tensor -- that is the check that a container agrees with the
 kernel set it is being packed for.
 
-**q8 sources.** The quantized chunk format is a property of the TENSOR, not of
+**Source forms.** The quantized chunk format is a property of the TENSOR, not of
 the container: the stock 35B keeps only its lm_head at q8, its fine-tunes pack
 attention, linear-attention and shared-expert projections at q8 and only the
 routed experts at q4_1, and a Qwen3.5 container stores `ssm_out_proj` and
@@ -254,12 +254,18 @@ chunk hold the same 32-row x 256-column tile, so the chunk index laws, the
 plan, the manifest and the kernels are unchanged; the packer is the only place
 that knows. There is no separate re-quantizing op.
 
+A Q4_K source (4736-byte chunks, what FLM 1.0.3+ writes) is accepted the same
+way and transcoded to q4_1 on the way in, for the same reason and through the
+same seam -- but nearly free, because Q4_K's scale and min already carry the
+pool's granularity and index (OPEN-QUANT-Q4K). So the three chunk ops read
+three source forms and refuse everything else by name.
+
 **Acceptance criteria:**
 - Layer pool, consts blob (linear and attention), lm_head pool and ptab are byte-equal to `legacy_pools.py` on random-byte tensors of the right sizes.
 - A small weight larger than its slot is refused (`does not fit its 4096 B slot`).
 - On a synthetic container mixing one q8 and one q4_1 tensor: the q8 tensor's pool bytes equal `requant_q4_1` of its chunks put through the same `std_perm` order; the q4_1 tensor's are the verbatim chunk copy they were before q8 sources existed; and the whole pool has the same FNV-1a in NumPy and in C++ (`tests/test_pack_plan.py`, `src/open_qwen36/pools_test.cpp`, which writes the container as a real `.q4nx`).
 - A container that cannot report a tensor's chunk size is read as q4_1, so the frozen pools above are unaffected.
-- A tensor with 1280-byte chunks is refused by both packers, the message naming the tensor and `1280`; it says what the count probably is (8704 = q8, 4736 = Q4_K, 1280 / 2560 = a smaller chunk geometry) rather than guessing "FLM 1.0.3 / Q4_K?".
+- A tensor with 1280-byte chunks is refused by both packers, the message naming the tensor, `1280`, the three widths that ARE read (5120 q4_1, 8704 q8, 4736 Q4_K) and what 1280 probably is -- rather than guessing "FLM 1.0.3 / Q4_K?", which is what it used to say about any unfamiliar width.
 - `requant_q4_1` (q8 chunks -> q4_1 chunks) and `transpose` (`[rows, cols]` -> `[cols, rows]`) produce identical bytes in NumPy and C++: both sides build the same synthetic q8 chunks and assert the same FNV-1a of the output (`tests/test_qwen35.py`, `src/open_qwen36/pools_test.cpp`).
 - Every value of a re-quantized block lands within `d/2` of its q4_1 reading, `d` being the block's stored scale: `m` is the minimum rounded toward -inf in bf16 and `d = (max - m)/15` rounded toward +inf, so `[m, m + 15d]` covers the block whatever bf16 did to either end.
 **The q8 lm_head's supertile order is a function of K.** A band is 128 output rows = 4 row
@@ -386,6 +392,83 @@ fallback its three siblings no longer need. `.claude/plans/q8m-hw-results.md` §
 reduces over `lin_value_width` -- 4096 on the 9B and 4B, 2048 on the 2B and 0.8B -- not over
 `hidden`, so both K were already validated by the 35B pass and all four sizes compose with
 no `OPEN_KERNELS_UNVALIDATED`.
+
+### OPEN-QUANT-Q4K: the packers read Q4_K containers
+**Applies to:** openflowlm-next (`open_kernels/model/q4nx.py`,
+`open_kernels/recipes/pack.py`, `src/open_qwen36/pools.cpp`,
+`utilities/q4nx-build/q4nx/{gguf_tensor,model_converter,cli}.py`)
+**Test category:** unit (the transcode, both packers, the reference, the converter's
+writer) + manual (the hardware run: needs the NPU and a Q4_K container)
+**Tests:** `tests/test_quant_q4k.py`, `src/open_qwen36/pools_test.cpp`
+
+FLM 1.0.3+ writes a third quantized chunk form, `q4k_block_t`, 4736 B per 32-row x
+256-column tile. Packing the 35B MoE projections as q4_1 instead makes the closed runtime
+decode infinite `////` or segfault, so this is not a preference and the open engine cannot
+refuse it. Both packers shall accept it as a source for the three q4 chunk ops
+(`std_perm`, `expert_stripes`, `expert_down`) and transcode it to the pool's q4_1 chunk on
+the way in, exactly as a q8 source is re-quantized. `q8_perm` continues to demand q8: a
+kernel set built to stream a projection at q8 is not satisfied by Q4_K.
+`utilities/q4nx-build` shall also be able to WRITE the format (`--quant Q4_K`).
+
+The chunk, everything column-major over the tile:
+
+```
+scales[8][32] uint8 @ [0, 256)      index g*32 + r   (32-column group g, row r)
+mins  [8][32] uint8 @ [256, 512)    same index
+qs    [256][16]     @ [512, 4608)   byte k*16 + r/2, even row in the low nibble
+S     [32]    bf16  @ [4608, 4672)  index r          one super-block per chunk
+M     [32]    bf16  @ [4672, 4736)  index r          stored NEGATED
+value(r, k) = S[r] * scales[k/32][r] * nib + M[r] * mins[k/32][r]
+```
+
+**Nothing above the packer changes.** Q4_K's scale and min already have the pool's
+granularity AND its index, so the transcode is `d = bf16(S*scales)`, `m = bf16(M*mins)`
+in place, plus a byte de-interleave of the nibbles (Q4_K keeps a column's 32 rows in 16
+contiguous bytes; the pool splits rows 0-15 and 16-31 into two 2048-byte planes, so q4_1
+byte `h*2048 + k*8 + j` is Q4_K byte `k*16 + h*8 + j`, values and parity unchanged). No
+chunk index law, plan, manifest, kernel or build key moves, and no kernel point is
+needed.
+
+**What it costs.** The exact product of a bf16 `S` and a uint8 `scales` needs 16
+significand bits and the pool's `d` holds 8, so each group's scale and min take one bf16
+half-ulp -- `2^-8` relative each. Where the two terms cancel the error can exceed `2^-8`
+of the value, which is why the bound below is stated on `|scale term| + |min term|`.
+Measured over all 108 Q4_K tensors of a real container: **0.48% relative weight RMS**,
+against 8% for the q8 -> q4_1 re-quantization the packer already does.
+
+**A source that cannot be read as Q4_K.** ggml has no Q4_K encoder, so a q5 / q6 / float
+source under a Q4_K target is re-quantized onto q4_1's grid and then packed as Q4_K. The
+two disagree on the sign of the min -- q4_1 stores an added `m` (<= 0), Q4_K a subtracted
+magnitude (>= 0) -- so the converter's fallback negates it. Without that the weights come
+out mirrored about each block's minimum and nothing downstream notices.
+
+**Acceptance criteria:**
+- A synthetic Q4_K chunk transcoded to q4_1 and read back as `nib*d + m` equals `S*scales*q + M*mins` computed in f64 from the same bytes, every value within `2^-8 * (|S*scales*q| + |M*mins|)` and no more. Measured worst case: 0.99 of that bound in C++, so the bound is tight rather than slack.
+- The nibble de-interleave is exact: for every `(r, k)` the uint4 at q4_1 nibble `(r/16)*4096 + k*16 + (r%16)` equals the one at Q4_K byte `k*16 + r/2`, nibble `r%2`.
+- The 256 metadata slots do not move: `d[i]` comes from `S[i%32] * scales[i]`, `m[i]` from `M[i%32] * mins[i]`, and every `m` is <= 0.
+- NumPy and C++ produce the same transcoded chunks and the same `std_perm` pool (FNV-1a `0x685dc049ec1ca2d7` and `0xb02083912551d9d3` on the shared synthetic vector).
+- A Q4_K tensor put through `std_perm` lands at the pool chunk positions a q4_1 tensor of the same shape does; a q4_1 tensor beside it is still a verbatim chunk copy, and `tests/test_pack_plan.py`'s frozen pools are unchanged.
+- `q8_perm` over a Q4_K tensor is refused naming the tensor and both byte counts; a width that is none of 5120 / 8704 / 4736 is refused naming the width and what it probably is -- and the refusal no longer GUESSES Q4_K for an unfamiliar width, since 4736 is now read.
+- `model/q4nx.py`'s `dq_tile` reads a Q4_K tensor as the transcoded q4_1 the NPU holds by default (the convention q8 already follows, so a slice comparison measures the kernels) and as the container's own Q4_K values under `requant=False`, which is the transcode's quality number.
+- Writer and reader agree: chunks written by `q4nx-build`'s `pack_q4k` from known `(scale, min, quant)` triples read back through `dq_chunks_q4_k` with the quants bit-exact and the values within 1e-2 relative L2 (the super-block re-fit's own accuracy).
+- The re-quantize fallback under a Q4_K target returns a non-negative min, and packing it round-trips to the q4_1 reading it came from.
+- `--quant Q4_K` on the HF-safetensors path is refused: `_store_q` quantizes with its own fixed per-role targets, so it would write a q4_1 container while claiming Q4_K.
+
+**Procedure (manual):** convert a GGUF for a validated shape twice, `--quant Q4_K` and
+`--quant Q4_1`, and run both through `src/open_qwen36/` on the same kernel set. The two
+containers hold the same source weights, so the only variable is the format.
+
+**Result 2026-09-08 (Qwen3.5-0.8B, condB fine-tune, 24 layers, Strix): PASS.** The Q4_K
+container -- 108 tensors at 4736 B beside 79 at 8704 -- is the first one that exists
+anywhere; no model on Atomic-Germ's Hugging Face or in FLM's registry ships the format
+yet. It loads, packs and decodes at **21.6 tok/s**, and its greedy output agrees with the
+q4_1 twin's for **36 of 37 tokens**, diverging only where a sentence-final `.` and `,`
+were a near-tie. Both continuations are coherent and say the same thing. Not yet done:
+`flm serve` / `utilities/flm-test`, and the fp64 slice comparison -- `make_decode.py`
+derives a spec from the container and this one puts `ffn` at q8 (the converter config
+pins `ffn_up`), which `recipes/qwen35.py` refuses for an unrelated reason (a mixed-format
+main core does not fit 16 KB). The kernels are unchanged by this requirement, so their
+correlation is the one OPEN-FAMILY-QWEN35 already records.
 
 ### OPEN-FAMILY-QWEN36MOE: greedy agreement with the fp64 reference on the 27B
 **Applies to:** openflowlm-next (`src/open_qwen36/`)

--- a/specs/open-engine/spec.md
+++ b/specs/open-engine/spec.md
@@ -455,20 +455,34 @@ out mirrored about each block's minimum and nothing downstream notices.
 - `--quant Q4_K` on the HF-safetensors path is refused: `_store_q` quantizes with its own fixed per-role targets, so it would write a q4_1 container while claiming Q4_K.
 
 **Procedure (manual):** convert a GGUF for a validated shape twice, `--quant Q4_K` and
-`--quant Q4_1`, and run both through `src/open_qwen36/` on the same kernel set. The two
-containers hold the same source weights, so the only variable is the format.
+`--quant Q4_1`, and run both through `src/open_qwen36/` on the same kernel set. Then serve
+each with `flm serve` on the open engine and run `utilities/flm-test --llm --tools` against
+it. The two containers hold the same source weights, so the only variable is the format.
 
 **Result 2026-09-08 (Qwen3.5-0.8B, condB fine-tune, 24 layers, Strix): PASS.** The Q4_K
 container -- 108 tensors at 4736 B beside 79 at 8704 -- is the first one that exists
 anywhere; no model on Atomic-Germ's Hugging Face or in FLM's registry ships the format
 yet. It loads, packs and decodes at **21.6 tok/s**, and its greedy output agrees with the
 q4_1 twin's for **36 of 37 tokens**, diverging only where a sentence-final `.` and `,`
-were a near-tie. Both continuations are coherent and say the same thing. Not yet done:
-`flm serve` / `utilities/flm-test`, and the fp64 slice comparison -- `make_decode.py`
-derives a spec from the container and this one puts `ffn` at q8 (the converter config
-pins `ffn_up`), which `recipes/qwen35.py` refuses for an unrelated reason (a mixed-format
-main core does not fit 16 KB). The kernels are unchanged by this requirement, so their
-correlation is the one OPEN-FAMILY-QWEN35 already records.
+were a near-tie. Both continuations are coherent and say the same thing.
+
+**Result 2026-09-09, through `flm serve` (same model, same box): PASS.** `flm-add` registers
+the container and the engine loads it on the open kernels, 24 of 24 layers resident, at the
+same spec hash the q4_1 twin derives -- the transcode is invisible above the packer, which is
+the point. `flm-test --llm` returns coherent, on-topic answers in stream mode. At temperature
+0 the two containers agree for the first 148 of 215 characters on a fixed prompt and then
+pick different phrasing for the same claim, at 16.67 tok/s against the twin's 16.86.
+`flm-test --tools` fails 5 of its 6 checks (no tool call issued), but the q4_1 twin fails the
+same 5 identically, so that is the 0.8B model and not the format.
+
+Getting there needed one converter fix, in this commit: `configs/qwen3.5_0.8b.json` pinned
+`up_proj` to Q8_0 while the shipped container stores it at q4_1, and the other three qwen3.5
+sizes never pinned it. A mixed `ffn` role is refused during spec derivation, so every
+container this converter built for the 0.8B was unusable by the open kernels, at q4_1 as much
+as at Q4_K. Unpinning it matches the shipped model and the sibling configs.
+
+Still open: the fp64 slice comparison, whose kernels are unchanged by this requirement, so
+their correlation is the one OPEN-FAMILY-QWEN35 already records.
 
 ### OPEN-FAMILY-QWEN36MOE: greedy agreement with the fp64 reference on the 27B
 **Applies to:** openflowlm-next (`src/open_qwen36/`)

--- a/specs/open-engine/tests/test_pack_plan.py
+++ b/specs/open-engine/tests/test_pack_plan.py
@@ -230,14 +230,19 @@ def test_the_numpy_and_cpp_packers_agree_on_the_mixed_container():
         "the mixed-container pool changed; update src/open_qwen36/pools_test.cpp too"
 
 
-def test_a_chunk_size_that_is_neither_q4_1_nor_q8_is_refused_by_name():
+def test_a_chunk_size_none_of_the_three_the_packer_reads_is_refused_by_name():
+    """The message names the tensor, the byte count and what the count probably is. It must
+    not GUESS Q4_K for a width that is not 4736 -- the reason this assertion exists (the
+    message used to read "FLM 1.0.3 / Q4_K?" for anything unfamiliar). Q4_K appears only in
+    the list of widths the packer does read (OPEN-QUANT-Q4K)."""
     m = MixedContainer()
     dst = np.zeros(NCH * pack.CH, np.uint8)
     with pytest.raises(ValueError) as e:
         pack.apply_op({"op": "std_perm", "tensor": BAD_NAME, "dst": 0, "nch": NCH, "in_dim": IN_DIM},
                       m, 0, dst)
     msg = str(e.value)
-    assert "mlp.up_proj.weight" in msg and "1280" in msg and "Q4_K" not in msg
+    assert "mlp.up_proj.weight" in msg and "1280" in msg
+    assert "1280 is a smaller chunk geometry" in msg
 
 
 def _write_container(path, tensors):

--- a/specs/open-engine/tests/test_quant_q4k.py
+++ b/specs/open-engine/tests/test_quant_q4k.py
@@ -1,0 +1,365 @@
+# Traces: OPEN-QUANT-Q4K, OPEN-PACK-PLAN (canonical spec: specs/open-engine/spec.md)
+"""Q4_K containers: the 4736-byte chunk, its transcode to the pool's q4_1 chunk, and the
+agreement between the converter that writes the format and the packers that read it.
+
+The plan is specs/open-engine/plans/q4k-containers.md.
+
+A Q4_K chunk holds the same 32-row x 256-column tile a q4_1 chunk does, and its scale and
+min have the same granularity -- one pair per (row, 32-column group) -- so the transcode
+is two multiplies per entry plus a byte de-interleave, and no chunk index law, plan,
+manifest or kernel moves. What it costs is one bf16 rounding of each product, which the
+first test bounds exactly.
+
+  q4k chunk, 4736 B:  scales[8][32] uint8 at [0, 256)    index g*32 + r
+                      mins  [8][32] uint8 at [256, 512)  same index
+                      qs    [256][16]      at [512, 4608)  byte k*16 + r/2, even row low
+                      S     [32]    bf16   at [4608, 4672) index r
+                      M     [32]    bf16   at [4672, 4736) index r, stored NEGATED
+  value(r, k) = S[r] * scales[k/32][r] * nib + M[r] * mins[k/32][r]
+
+The same synthetic chunks are built, transcoded and hashed by
+src/open_qwen36/pools_test.cpp, so the two packers are held to each other byte for byte
+without a model file.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from recipes import pack
+
+from test_pack_plan import _fnv1a, _lcg_bytes
+
+REPO = Path(__file__).resolve().parents[3]
+
+Q4K = 4736
+CH = pack.CH
+Q8 = pack.Q8
+
+OUT_DIM, IN_DIM = 128, 512
+NCH = (OUT_DIM // 32) * (IN_DIM // 256)        # 8 chunks: 32 rows x 256 K each
+Q4K_NAME = "model.layers.{l}.mlp.gate_proj.weight"
+Q4_NAME = "model.layers.{l}.mlp.down_proj.weight"
+BAD_NAME = "model.layers.{l}.mlp.up_proj.weight"
+
+# FNV-1a 64 of the transcoded chunks of _q4k_vector(NCH). src/open_qwen36/pools_test.cpp
+# asserts the same number on the same bytes, so a divergence in either packer fails one
+# of the two tests.
+Q4K_TRANSCODE_FNV1A = 0x685DC049EC1CA2D7
+# ... and of the pool std_perm puts them in, beside a q4_1 tensor.
+Q4K_POOL_FNV1A = 0xB02083912551D9D3
+
+
+def _bf16(u16) -> np.ndarray:
+    return (np.asarray(u16, np.uint16).astype(np.uint32) << 16).view(np.float32)
+
+
+def _q4k_vector(nch: int) -> np.ndarray:
+    """The vector pools_test.cpp builds, byte for byte: per chunk one LCG seeded from the
+    chunk index; 4608 plain bytes (the uint8 scales, the uint8 mins and the nibbles), then
+    32 bf16 `S` with exponent 0x76 (finite, positive) and 32 bf16 `M` with the same
+    exponent and the sign bit set -- the converter stores the min already negated, and
+    Q4_K's own dmin is non-negative, so a real `M` is never positive."""
+    M32 = 0xFFFFFFFF
+    out = np.zeros((nch, Q4K), np.uint8)
+    for c in range(nch):
+        s = (0x9E3779B9 * (c + 1)) & M32
+        for i in range(4608):
+            s = (s * 1664525 + 1013904223) & M32
+            out[c, i] = s >> 24
+        sm = np.zeros(64, np.uint16)
+        for i in range(32):
+            s = (s * 1664525 + 1013904223) & M32
+            sm[i] = 0x3B00 | (s >> 24)
+        for i in range(32):
+            s = (s * 1664525 + 1013904223) & M32
+            sm[32 + i] = 0xBB00 | (s >> 24)
+        out[c, 4608:] = sm.view(np.uint8)
+    return out
+
+
+def _q4k_nibbles(chunk) -> np.ndarray:
+    """[4736] chunk bytes -> [32, 256] uint8 (row, k), read straight off the layout above:
+    byte 512 + k*16 + r/2, low nibble for an even row."""
+    b = np.asarray(chunk, np.uint8)
+    qs = b[512:4608].reshape(256, 16)                       # [k, r // 2]
+    r = np.arange(32)
+    lo = qs[:, r // 2] & 0xF
+    hi = qs[:, r // 2] >> 4
+    return np.where(r % 2 == 0, lo, hi).T.astype(np.uint8)  # [r, k]
+
+
+def _q4_1_nibbles(chunk) -> np.ndarray:
+    """[5120] pool chunk bytes -> [32, 256] uint8 (row, k): nibble (r/16)*4096 + k*16 + r%16."""
+    b = np.asarray(chunk, np.uint8)
+    n = np.empty(8192, np.uint8)
+    n[0::2] = b[1024:] & 0xF
+    n[1::2] = b[1024:] >> 4
+    r = np.arange(32)[:, None]
+    k = np.arange(256)[None, :]
+    return n[(r // 16) * 4096 + k * 16 + (r % 16)]
+
+
+def _q4k_exact(chunk) -> np.ndarray:
+    """[4736] chunk bytes -> [32, 8, 32] f64 (row, block, lane), the value the container
+    says, in f64. Written from the layout table, not from the implementation."""
+    b = np.asarray(chunk, np.uint8)
+    scales = b[:256].astype(np.float64).reshape(8, 32)                       # [g, r]
+    mins = b[256:512].astype(np.float64).reshape(8, 32)                      # [g, r]
+    S = _bf16(np.ascontiguousarray(b[4608:4672]).view(np.uint16)).astype(np.float64)
+    M = _bf16(np.ascontiguousarray(b[4672:4736]).view(np.uint16)).astype(np.float64)
+    nib = _q4k_nibbles(b).astype(np.float64).reshape(32, 8, 32)              # [r, g, i]
+    return (S[:, None, None] * scales.T[:, :, None] * nib
+            + M[:, None, None] * mins.T[:, :, None])
+
+
+class Q4kContainer:
+    """One Q4_K tensor, one q4_1 tensor and one with 1280-byte chunks -- the shape of a
+    container from FLM 1.0.3+, which keeps Q4_K where the closed runtime demands it and
+    leaves the rest alone."""
+
+    def __init__(self):
+        self.data = {
+            Q4K_NAME.replace("{l}", "0"): _q4k_vector(NCH).reshape(-1),
+            Q4_NAME.replace("{l}", "0"): _lcg_bytes(0x1234567, NCH * CH),
+            BAD_NAME.replace("{l}", "0"): _lcg_bytes(0x89ABCDE, NCH * 1280),
+        }
+        self.chunks = {Q4K_NAME.replace("{l}", "0"): Q4K,
+                       Q4_NAME.replace("{l}", "0"): CH,
+                       BAD_NAME.replace("{l}", "0"): 1280}
+
+    def raw(self, name):
+        return self.data[name]
+
+    def chunk_bytes_of(self, name):
+        return self.chunks[name]
+
+
+def _q4k_pool() -> np.ndarray:
+    m = Q4kContainer()
+    dst = np.zeros(2 * NCH * CH, np.uint8)
+    pack.apply_op({"op": "std_perm", "tensor": Q4K_NAME, "dst": 0, "nch": NCH, "in_dim": IN_DIM},
+                  m, 0, dst)
+    pack.apply_op({"op": "std_perm", "tensor": Q4_NAME, "dst": NCH * CH, "nch": NCH, "in_dim": IN_DIM},
+                  m, 0, dst)
+    return dst
+
+
+# ------------------------------------------------------------------- the transcode
+def test_the_transcode_reads_as_the_container_says():
+    """A transcoded chunk read as `nib*d + m` equals what the Q4_K bytes mean, to within
+    the bf16 rounding of the two products and no further. That rounding is the whole cost
+    of the format collapse: the exact product of a bf16 `S` and a uint8 `scales` needs 16
+    significand bits and the pool's `d` holds 8, so each group's scale moves by at most a
+    half-ulp of bf16 -- 2^-8 relative."""
+    src = _q4k_vector(NCH)
+    from q4nx import dq_chunks_q4_1
+    got = dq_chunks_q4_1(pack.q4k_to_q4_1(src)).astype(np.float64)
+
+    b = src
+    scales = b[:, :256].astype(np.float64).reshape(NCH, 8, 32).transpose(0, 2, 1)[..., None]
+    mins = b[:, 256:512].astype(np.float64).reshape(NCH, 8, 32).transpose(0, 2, 1)[..., None]
+    S = _bf16(np.ascontiguousarray(b[:, 4608:4672]).view(np.uint16)).astype(np.float64)
+    M = _bf16(np.ascontiguousarray(b[:, 4672:4736]).view(np.uint16)).astype(np.float64)
+    nib = np.stack([_q4k_nibbles(c) for c in b]).astype(np.float64).reshape(NCH, 32, 8, 32)
+    a = S[:, :, None, None] * scales * nib          # the scale term
+    c = M[:, :, None, None] * mins                  # the min term
+    want = a + c
+
+    tol = (2.0 ** -8 + 2.0 ** -20) * (np.abs(a) + np.abs(c))
+    err = np.abs(got - want)
+    assert (err <= tol).all(), f"worst {(err / np.maximum(tol, 1e-300)).max():.3f} x the bf16 bound"
+    assert err.max() > 0, "the test vector must actually exercise the rounding"
+
+
+def test_the_nibble_deinterleave_is_exact():
+    """Q4_K keeps a column's 32 rows in 16 contiguous bytes; the pool splits rows 0-15 and
+    16-31 into two 2048-byte planes. Nothing else about the nibbles changes -- both are
+    unsigned uint4 against a (scale, min) pair -- so this is equality, not a tolerance."""
+    src = _q4k_vector(NCH)
+    out = pack.q4k_to_q4_1(src)
+    for c in range(NCH):
+        assert np.array_equal(_q4_1_nibbles(out[c]), _q4k_nibbles(src[c])), f"chunk {c}"
+
+
+def test_the_scale_index_does_not_move():
+    """Both formats index their per-(group, row) metadata `g*32 + r`, so the transcode is a
+    multiply in place: no permutation of the 256 entries."""
+    src = _q4k_vector(1)
+    out = pack.q4k_to_q4_1(src)
+    d = _bf16(np.ascontiguousarray(out[0, :512]).view(np.uint16)).astype(np.float64)
+    m = _bf16(np.ascontiguousarray(out[0, 512:1024]).view(np.uint16)).astype(np.float64)
+    S = _bf16(np.ascontiguousarray(src[0, 4608:4672]).view(np.uint16)).astype(np.float64)
+    M = _bf16(np.ascontiguousarray(src[0, 4672:4736]).view(np.uint16)).astype(np.float64)
+    r = np.arange(256) % 32
+    want_d = S[r] * src[0, :256].astype(np.float64)
+    want_m = M[r] * src[0, 256:512].astype(np.float64)
+    assert (np.abs(d - want_d) <= 2.0 ** -8 * np.abs(want_d)).all()
+    assert (np.abs(m - want_m) <= 2.0 ** -8 * np.abs(want_m)).all()
+    assert (m <= 0).all(), "a real Q4_K min is stored negated, so the pool's m is never positive"
+
+
+def test_the_numpy_and_cpp_transcodes_agree():
+    """The gate on the two implementations. src/open_qwen36/pools_test.cpp builds the same
+    chunks and asserts this same FNV-1a; if either transcode changes, one of the two fails."""
+    assert _fnv1a(pack.q4k_to_q4_1(_q4k_vector(NCH)).tobytes()) == Q4K_TRANSCODE_FNV1A, \
+        "the Q4_K transcode changed; update src/open_qwen36/pools_test.cpp too"
+
+
+# ------------------------------------------------------------------- as a pack source
+def test_a_q4k_source_packs_in_the_same_chunk_order():
+    """The permutation is applied to transcoded chunks, exactly as it is to file chunks: a
+    Q4_K chunk and a q4_1 chunk hold the same 32 x 256 tile, so std_perm does not move."""
+    got = _q4k_pool()[:NCH * CH].reshape(NCH, CH)
+    want = pack.q4k_to_q4_1(_q4k_vector(NCH))[pack.std_perm(NCH, IN_DIM)]
+    assert np.array_equal(got, want)
+
+
+def test_a_q4_1_tensor_beside_it_is_still_a_verbatim_chunk_copy():
+    """The q4_1 path must not notice that Q4_K exists: still a chunk copy in std_perm
+    order, which is what keeps OPEN-PACK-PLAN's frozen pools byte-equal."""
+    m = Q4kContainer()
+    got = _q4k_pool()[NCH * CH:].reshape(NCH, CH)
+    src = m.raw(Q4_NAME.replace("{l}", "0")).reshape(NCH, CH)
+    assert np.array_equal(got, src[pack.std_perm(NCH, IN_DIM)])
+
+
+def test_the_numpy_and_cpp_packers_agree_on_a_q4k_container():
+    assert _fnv1a(_q4k_pool().tobytes()) == Q4K_POOL_FNV1A, \
+        "the Q4_K pool changed; update src/open_qwen36/pools_test.cpp too"
+
+
+def test_q8_perm_refuses_a_q4k_source():
+    """A kernel set built to stream a projection at q8 is not satisfied by Q4_K: the pool
+    would hold 5120-byte q4_1 half-tiles' worth of the wrong thing. Refused by name and
+    both byte counts."""
+    m = Q4kContainer()
+    with pytest.raises(ValueError) as e:
+        pack.q8_chunks_of(m, Q4K_NAME.replace("{l}", "0"), m.raw(Q4K_NAME.replace("{l}", "0")))
+    msg = str(e.value)
+    assert "gate_proj" in msg and "4736" in msg and "8704" in msg
+
+
+def test_a_chunk_width_that_is_none_of_the_three_is_still_refused():
+    """1280 stays refused, naming the tensor, the count and what the count probably is --
+    and the message no longer offers 4736 as an example of something unreadable."""
+    m = Q4kContainer()
+    with pytest.raises(ValueError) as e:
+        pack.q4_chunks_of(m, BAD_NAME.replace("{l}", "0"), m.raw(BAD_NAME.replace("{l}", "0")))
+    msg = str(e.value)
+    assert "up_proj" in msg and "1280" in msg
+    assert "4736" in msg, "the accepted widths should now include Q4_K"
+    assert "Q4_K (FLM 1.0.3), which needs a different dequant" not in msg
+
+
+# ------------------------------------------------------------------- the fp64 reader
+def test_dq_chunks_q4_k_reads_the_container_exactly():
+    """The reference dequant used by the replica reads the Q4_K bytes themselves, with no
+    bf16 collapse -- that is what makes an A/B against the transcode measure the transcode."""
+    from q4nx import dq_chunks_q4_k
+    src = _q4k_vector(NCH)
+    got = dq_chunks_q4_k(src).astype(np.float64)
+    want = np.stack([_q4k_exact(c) for c in src])
+    assert np.abs(got - want).max() <= 1e-6 * np.abs(want).max()
+
+
+def test_dq_tile_reads_the_pool_by_default_and_the_container_on_request():
+    """`dq_tile` mirrors the packer's decision, as it does for q8: by default a Q4_K tensor
+    reads as the transcoded q4_1 the NPU actually holds, so a slice comparison measures the
+    KERNELS; `requant=False` reads the container's own Q4_K values, and the gap between the
+    two readings is the transcode's quality number."""
+    from q4nx import CHUNK_Q4K, Q4NX, dq_chunks_q4_1, dq_chunks_q4_k
+    src = _q4k_vector(NCH)
+    raw = src.reshape(-1).tobytes()
+
+    me = SimpleNamespace(requant_q8=True)          # the default a real Q4NX carries
+    packed = Q4NX.dq_tile(me, raw, OUT_DIM, IN_DIM, chunk=CHUNK_Q4K)
+    native = Q4NX.dq_tile(me, raw, OUT_DIM, IN_DIM, chunk=CHUNK_Q4K, requant=False)
+    assert packed.shape == (OUT_DIM, IN_DIM) and native.shape == (OUT_DIM, IN_DIM)
+
+    def _raster(v):
+        return v.reshape(NCH, 32, 256).reshape(OUT_DIM // 32, IN_DIM // 256, 32, 256) \
+                .transpose(0, 2, 1, 3).reshape(OUT_DIM, IN_DIM)
+
+    assert np.allclose(packed, _raster(dq_chunks_q4_1(pack.q4k_to_q4_1(src)).reshape(NCH, 32, 256)))
+    assert np.allclose(native, _raster(dq_chunks_q4_k(src).reshape(NCH, 32, 256)))
+    assert not np.array_equal(packed, native), "the two readings must actually differ"
+
+
+# ------------------------------------------------------- the writer and the reader agree
+def _converter_packer():
+    """`utilities/q4nx-build`'s Q4_K writer, loaded by path: the converter package's name
+    (`q4nx`) collides with open_kernels/model/q4nx.py, so it is never put on sys.path."""
+    p = REPO / "utilities" / "q4nx-build" / "q4nx" / "gguf_tensor.py"
+    spec = importlib.util.spec_from_file_location("q4nx_build_gguf_tensor", p)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_the_converters_writer_and_our_reader_agree_on_the_layout():
+    """The only cross-check available until a Q4_K container ships: bytes written by
+    `q4nx-build` from known (scale, min, quant) triples, read back by our dequant.
+
+    The nibbles come back exactly -- that is the layout check, and a transposed or
+    misaligned qs plane could not survive it. The values come back to the re-fit's own
+    accuracy: the writer re-expresses each 8-group super-block's exact scales as
+    (bf16 S, uint8 s_j), which is where the small residual lives.
+    """
+    torch = pytest.importorskip("torch")
+    gt = _converter_packer()
+    rows, cols = 64, 512
+    rng = np.random.default_rng(7)
+    t = rng.uniform(0.002, 0.02, (rows, cols // 32)).astype(np.float32)       # per-group scale
+    u = rng.uniform(0.0, 0.05, (rows, cols // 32)).astype(np.float32)         # per-group min
+    q = rng.integers(0, 16, (rows, cols)).astype(np.float32)
+
+    packed = gt.pack_q4k(torch.from_numpy(t), torch.from_numpy(u), torch.from_numpy(q),
+                         row_block_size=32, col_block_size=256, keep_block_in_2D=False)
+    chunks = packed.contiguous().view(torch.uint8).numpy().reshape(-1, Q4K)
+    assert chunks.shape[0] == (rows // 32) * (cols // 256)
+
+    from q4nx import dq_chunks_q4_k
+    got = dq_chunks_q4_k(chunks).reshape(-1, 32, 256)
+    want = (t[:, :, None] * q.reshape(rows, cols // 32, 32) - u[:, :, None]).reshape(rows, cols)
+    want = want.reshape(rows // 32, 32, cols // 256, 256).transpose(0, 2, 1, 3).reshape(-1, 32, 256)
+
+    nib = np.stack([_q4k_nibbles(c) for c in chunks])
+    q_chunked = q.reshape(rows // 32, 32, cols // 256, 256).transpose(0, 2, 1, 3).reshape(-1, 32, 256)
+    assert np.array_equal(nib.astype(np.float32), q_chunked), "the quants must survive the round trip exactly"
+
+    rel = np.linalg.norm(got - want) / np.linalg.norm(want)
+    assert rel < 1e-2, f"writer and reader disagree by {rel:.4g} relative L2"
+
+
+def test_a_source_that_cannot_be_read_as_q4k_still_packs_with_the_right_min_sign():
+    """ggml has no Q4_K encoder, so a q8 / q5 / q6 source under a Q4_K target is
+    re-quantized onto q4_1's grid and then packed as Q4_K. The two formats disagree on the
+    sign of the min -- q4_1 stores an added `m` (<= 0), Q4_K a subtracted magnitude -- so
+    the fallback has to negate it. Without that the weights come out mirrored about each
+    block's minimum, and nothing downstream would notice."""
+    torch = pytest.importorskip("torch")
+    gguf = pytest.importorskip("gguf")
+    gt = _converter_packer()
+
+    rows, cols = 32, 256
+    w = np.random.default_rng(11).normal(0, 0.05, (rows, cols)).astype(np.float32)
+    q8 = gguf.quantize(w, gguf.GGMLQuantizationType.Q8_0).copy()
+    t = gt.GGUFTensor("w", (cols, rows), q8, gguf.GGMLQuantizationType.Q8_0)
+
+    d, u, qw = t._requantize_to(gguf.GGMLQuantizationType.Q4_K)
+    assert (u.numpy() >= 0).all(), "Q4_K's min is a subtracted magnitude, never negative"
+
+    packed = gt.pack_q4k(d, u, qw, row_block_size=32, col_block_size=256, keep_block_in_2D=False)
+    chunks = packed.contiguous().view(torch.uint8).numpy().reshape(-1, Q4K)
+
+    from q4nx import dq_chunks_q4_k
+    got = dq_chunks_q4_k(chunks).reshape(rows, cols)
+    want = (d.numpy()[:, :, None] * qw.numpy().reshape(rows, cols // 32, 32)
+            - u.numpy()[:, :, None]).reshape(rows, cols)
+    rel = np.linalg.norm(got - want) / np.linalg.norm(want)
+    assert rel < 1e-2, f"the fallback's values do not survive the Q4_K pack ({rel:.4g})"

--- a/src/open_qwen36/README.md
+++ b/src/open_qwen36/README.md
@@ -551,8 +551,12 @@ on a memory-starved box, not the kernels.
   per tensor, so a container mixing q8 and q4_1 -- which is what the 35B fine-tunes
   ship, q8 attention and shared experts over q4_1 routed experts -- loads and packs;
   the q8 projections the kernel set was built for go into the pool at q8, the rest are
-  re-quantized to q4_1 (above). Anything that is neither (Q4_K's 4736-byte chunks, the
-  1280 / 2560-byte geometries) is refused, naming the tensor.
+  re-quantized to q4_1 (above). **Both weight formats are read:** a container written
+  by FLM 1.0.3+ stores Q4_K super-blocks (4736-byte chunks) where 1.0.2 stored q4_1,
+  and those are transcoded into the pool's q4_1 chunk on the way in -- nearly free,
+  since Q4_K's scale and min already have the pool's granularity, and no kernel,
+  manifest or build key changes (OPEN-QUANT-Q4K). Anything else (the 1280 / 2560-byte
+  geometries) is refused, naming the tensor.
 - **Memory.** The engine holds 21.6 GB of NPU buffers, and on Windows those
   are managed by the video memory manager and can be evicted under pressure —
   the first server run on a 47 GB box with 0.6 GB free hung a kernel (ERT

--- a/src/open_qwen36/pools.cpp
+++ b/src/open_qwen36/pools.cpp
@@ -47,6 +47,7 @@ std::vector<size_t> std_perm(size_t nch, size_t in_dim) {
 
 constexpr size_t Q8_CHUNK = 8704;    // 256 bf16 scales then 8192 int8 codes
 constexpr size_t Q4_CHUNK = 5120;    // 256 bf16 d, 256 bf16 m, then 4096 B of nibbles
+constexpr size_t Q4K_CHUNK = 4736;   // 256 uint8 scales, 256 uint8 mins, 4096 B of nibbles, 32 bf16 S, 32 bf16 M
 constexpr size_t Q8H_SCALES = 256;   // a half-tile's 128 bf16 scales
 constexpr size_t Q8H_CODES = 4096;   // a half-tile's 4096 int8 codes
 constexpr unsigned Q8H_ROWS = 16;
@@ -90,6 +91,14 @@ uint16_t bf16_ceil(float x) {
     return static_cast<uint16_t>((u >> 31) ? (u >> 16) : ((u + 0xFFFFu) >> 16));
 }
 
+/// f32 -> bf16, round to nearest even. The directed roundings above make a re-quantized
+/// block's range cover its source; a Q4_K scale is not a range end but a value being
+/// re-expressed, so it takes the nearest bf16.
+uint16_t bf16_rne(float x) {
+    const uint32_t u = bits(x);
+    return static_cast<uint16_t>((u + 0x7FFFu + ((u >> 16) & 1u)) >> 16);
+}
+
 /// Code index of (row, block, lane) inside a chunk: the raster both formats use.
 inline unsigned code_index(unsigned r, unsigned b, unsigned i) {
     return (r / 16) * 4096 + b * 512 + i * 16 + (r % 16);
@@ -103,9 +112,8 @@ const uint8_t* raw(const Q4nxFile& m, const std::string& name, size_t need, size
     return p;
 }
 
-/// What a chunk size that is neither 5120 nor 8704 probably is, for the refusal message.
+/// What a chunk size the packer does not read probably is, for the refusal message.
 std::string chunk_guess(size_t ch) {
-    if (ch == 4736) return "Q4_K (FLM 1.0.3), which needs a different dequant";
     if (ch == 1280 || ch == 2560) return "a smaller chunk geometry (" + std::to_string(ch * 8192 / Q4_CHUNK) +
                                          " values per chunk instead of 8192)";
     return "not a chunk format this packer knows";
@@ -125,9 +133,15 @@ const uint8_t* q4_source(const Q4nxFile& m, const std::string& name, size_t chun
         requant_q4_1_chunks(src, nch, tmp.data());
         return tmp.data();
     }
+    if (src_ch == Q4K_CHUNK && ch == Q4_CHUNK) {
+        const uint8_t* src = raw(m, name, (chunk0 + nch) * Q4K_CHUNK) + chunk0 * Q4K_CHUNK;
+        tmp.resize(nch * Q4_CHUNK);
+        q4k_to_q4_1_chunks(src, nch, tmp.data());
+        return tmp.data();
+    }
     fail(name + " has " + std::to_string(src_ch) + "-byte quant chunks; the packer reads " +
-         std::to_string(ch) + " (q4_1) and " + std::to_string(Q8_CHUNK) + " (q8); " + std::to_string(src_ch) +
-         " is " + chunk_guess(src_ch));
+         std::to_string(ch) + " (q4_1), " + std::to_string(Q8_CHUNK) + " (q8) and " +
+         std::to_string(Q4K_CHUNK) + " (Q4_K); " + std::to_string(src_ch) + " is " + chunk_guess(src_ch));
 }
 
 }  // namespace
@@ -173,6 +187,29 @@ void requant_q4_1_chunks(const uint8_t* src, size_t nch, uint8_t* dst) {
                 }
             }
         }
+    }
+}
+
+void q4k_to_q4_1_chunks(const uint8_t* src, size_t nch, uint8_t* dst) {
+    for (size_t c = 0; c < nch; ++c) {
+        const uint8_t* s = src + c * Q4K_CHUNK;
+        uint8_t* o = dst + c * Q4_CHUNK;
+        // d[g*32 + r] = bf16(S[r] * scales[g*32 + r]), m likewise from M and mins -- the
+        // two formats already agree on the meta index, so this is a multiply in place.
+        for (unsigned i = 0; i < 256; ++i) {
+            uint16_t sh, mh;
+            std::memcpy(&sh, s + 4608 + 2 * (i % 32), 2);
+            std::memcpy(&mh, s + 4672 + 2 * (i % 32), 2);
+            const uint16_t d = bf16_rne(bf16_to_f32(sh) * static_cast<float>(s[i]));
+            const uint16_t mn = bf16_rne(bf16_to_f32(mh) * static_cast<float>(s[256 + i]));
+            std::memcpy(o + 2 * i, &d, 2);
+            std::memcpy(o + 512 + 2 * i, &mn, 2);
+        }
+        // Q4_K holds a column's 32 rows in 16 contiguous bytes; the pool splits rows 0-15
+        // and 16-31 into two 2048-byte planes. Nibble values and parity are unchanged.
+        for (unsigned k = 0; k < 256; ++k)
+            for (unsigned h = 0; h < 2; ++h)
+                std::memcpy(o + 1024 + h * 2048 + k * 8, s + 512 + k * 16 + h * 8, 8);
     }
 }
 

--- a/src/open_qwen36/pools.hpp
+++ b/src/open_qwen36/pools.hpp
@@ -17,7 +17,11 @@
 /// difference -- which is what lets the Qwen3.6-35B fine-tunes (q8 attention,
 /// linear-attention and shared experts; q4_1 routed experts) and Qwen3.5's q8
 /// `ssm_out_proj` run on kernels that only have a q4_1 GEMV (OPEN-PACK-PLAN).
-/// Any other chunk size is refused, naming the tensor.
+///
+/// A Q4_K source (4736-byte chunks, what FLM 1.0.3+ writes) is accepted the same way and
+/// transcoded to q4_1 (`q4k_to_q4_1_chunks`). That one is nearly free: Q4_K's scale and
+/// min already have the pool's granularity and index, so only the two bf16 products
+/// round (OPEN-QUANT-Q4K). Any other chunk size is refused, naming the tensor.
 ///
 /// A projection the kernel set streams AT q8 (the manifest carries `q8_perm` instead of
 /// `std_perm` for it) is not re-quantized at all: each 8704-byte container chunk is split
@@ -57,6 +61,19 @@ void apply(const PackOp& op, const Q4nxFile& m, int layer, uint8_t* dst, size_t 
 /// its reading. `recipes/pack.py requant_q4_1` is the same arithmetic in NumPy; pools_test
 /// and tests/test_qwen35.py check the two on the same vectors.
 void requant_q4_1_chunks(const uint8_t* src, size_t nch, uint8_t* dst);
+/// `nch` Q4_K chunks (4736 B each) -> `nch` q4_1 chunks (5120 B each), in the SAME chunk
+/// order. Both formats hold a 32-row x 256-column tile with one (scale, min) pair per
+/// (row, 32-column group) at the SAME meta index `g*32 + r`, so nothing is re-quantized:
+///   scales[8][32] uint8 @ [0, 256)     mins[8][32] uint8 @ [256, 512)
+///   qs[256][16]         @ [512, 4608)  byte k*16 + r/2, even row in the low nibble
+///   S[32] bf16          @ [4608, 4672) M[32] bf16 @ [4672, 4736), M already negated
+///   value = S[r]*scales[g][r]*nib + M[r]*mins[g][r], which is the pool's nib*d + m
+/// The transcode is the two products rounded to bf16 -- the one place values move, by at
+/// most a half-ulp, 2^-8 relative -- plus a byte de-interleave of the nibbles, since the
+/// pool splits rows 0-15 and 16-31 into two 2048-byte planes. `recipes/pack.py
+/// q4k_to_q4_1` is the same in NumPy; pools_test and tests/test_quant_q4k.py hash the
+/// same vectors (OPEN-QUANT-Q4K).
+void q4k_to_q4_1_chunks(const uint8_t* src, size_t nch, uint8_t* dst);
 /// One container q8 chunk (8704 B: scales[256] bf16 then codes[8192] int8, 32 rows x 256 K)
 /// -> its 16-row half-tile `half` (5120 B: scales[128] bf16 at [0, 256), codes[4096] int8 at
 /// [256, 4352), zero pad). Rows 16*half .. 16*half+15. The container's row-block stride is

--- a/src/open_qwen36/pools_test.cpp
+++ b/src/open_qwen36/pools_test.cpp
@@ -14,12 +14,14 @@
 #include <fstream>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "open_qwen36/pools.hpp"
 #include "open_qwen36/q4nx_file.hpp"
 
 using open_qwen36::pools::q8_half_tile;
+using open_qwen36::pools::q4k_to_q4_1_chunks;
 using open_qwen36::pools::requant_q4_1_chunks;
 using open_qwen36::pools::transpose_bytes;
 
@@ -36,6 +38,10 @@ constexpr uint64_t MIXED_FNV1A = 0x548390807a90d2ebull;
 // The pool the SAME q8 tensor packs to when the kernel set streams it at q8 (`q8_perm`,
 // OPEN-QUANT-Q8). specs/open-engine/tests/test_quant_q8.py asserts this number.
 constexpr uint64_t Q8_POOL_FNV1A = 0x8d4a3cf75e4cbffaull;
+// The Q4_K chunks of q4k_vector(NCH) transcoded to q4_1, and the pool std_perm puts them
+// in beside a q4_1 tensor (OPEN-QUANT-Q4K). tests/test_quant_q4k.py asserts both.
+constexpr uint64_t Q4K_TRANSCODE_FNV1A = 0x685dc049ec1ca2d7ull;
+constexpr uint64_t Q4K_POOL_FNV1A = 0xb02083912551d9d3ull;
 
 int failures = 0;
 
@@ -131,26 +137,33 @@ std::vector<size_t> band_perm(size_t nch, size_t in_dim) {
     return p;
 }
 
-/// Write a synthetic `.q4nx` (safetensors: 8-byte header length, JSON header, data) with
-/// one q8 tensor, one q4_1 tensor and one whose chunks are neither.
-std::string write_mixed_container(const std::vector<uint8_t>& q8, const std::vector<uint8_t>& q4,
-                                  const std::vector<uint8_t>& bad) {
-    auto entry = [](const char* name, size_t nch, size_t ch, size_t off) {
-        return std::string("\"") + name + "\":{\"dtype\":\"I8\",\"shape\":[" + std::to_string(nch) + "," +
-               std::to_string(ch) + "],\"data_offsets\":[" + std::to_string(off) + "," +
-               std::to_string(off + nch * ch) + "]}";
-    };
-    std::string hdr = "{" + entry(Q8_NAME, NCH, Q8_CH, 0) + "," +
-                      entry(Q4_NAME, NCH, Q4_CH, q8.size()) + "," +
-                      entry(BAD_NAME, NCH, BAD_CH, q8.size() + q4.size()) + "}";
-    const std::string path = (std::filesystem::temp_directory_path() / "open_qwen36_pools_test.q4nx").string();
+/// Write a synthetic `.q4nx` (safetensors: 8-byte header length, JSON header, data) from
+/// {tensor name, chunk width, bytes} triples -- the mixed q8 / q4_1 container and the Q4_K
+/// one differ only in what they hold.
+struct Tensor {
+    const char* name;
+    size_t ch;
+    const std::vector<uint8_t>* data;
+};
+
+std::string write_container(const std::string& stem, const std::vector<Tensor>& ts) {
+    std::string hdr = "{";
+    size_t off = 0;
+    for (size_t i = 0; i < ts.size(); ++i) {
+        const size_t n = ts[i].data->size();
+        hdr += (i ? "," : "") + std::string("\"") + ts[i].name + "\":{\"dtype\":\"I8\",\"shape\":[" +
+               std::to_string(n / ts[i].ch) + "," + std::to_string(ts[i].ch) + "],\"data_offsets\":[" +
+               std::to_string(off) + "," + std::to_string(off + n) + "]}";
+        off += n;
+    }
+    hdr += "}";
+    const std::string path = (std::filesystem::temp_directory_path() / (stem + ".q4nx")).string();
     std::ofstream f(path, std::ios::binary | std::ios::trunc);
     uint64_t n = hdr.size();
     f.write(reinterpret_cast<const char*>(&n), 8);
     f.write(hdr.data(), static_cast<std::streamsize>(hdr.size()));
-    f.write(reinterpret_cast<const char*>(q8.data()), static_cast<std::streamsize>(q8.size()));
-    f.write(reinterpret_cast<const char*>(q4.data()), static_cast<std::streamsize>(q4.size()));
-    f.write(reinterpret_cast<const char*>(bad.data()), static_cast<std::streamsize>(bad.size()));
+    for (const Tensor& t : ts)
+        f.write(reinterpret_cast<const char*>(t.data->data()), static_cast<std::streamsize>(t.data->size()));
     f.close();
     return path;
 }
@@ -179,7 +192,8 @@ void mixed_container_tests() {
     const std::vector<uint8_t> q8 = q8_vector(NCH);
     const std::vector<uint8_t> q4 = lcg_bytes(0x1234567u, NCH * Q4_CH);
     const std::vector<uint8_t> bad = lcg_bytes(0x89ABCDEu, NCH * BAD_CH);
-    const std::string path = write_mixed_container(q8, q4, bad);
+    const std::string path = write_container("open_qwen36_pools_test",
+                                             {{Q8_NAME, Q8_CH, &q8}, {Q4_NAME, Q4_CH, &q4}, {BAD_NAME, BAD_CH, &bad}});
     open_qwen36::Q4nxFile f(path);
 
     check(f.chunk_bytes(Q8_NAME) == Q8_CH && f.chunk_bytes(Q4_NAME) == Q4_CH &&
@@ -216,8 +230,8 @@ void mixed_container_tests() {
     } catch (const std::exception& e) {
         msg = e.what();
     }
-    check(msg.find("mlp.up_proj.weight") != std::string::npos && msg.find("1280") != std::string::npos &&
-              msg.find("Q4_K") == std::string::npos,
+    check(msg.find("mlp.up_proj.weight") != std::string::npos &&
+              msg.find("1280 is a smaller chunk geometry") != std::string::npos,
           "a 1280-byte chunk tensor is refused, naming it and 1280 (\"" + msg + "\")");
 
     // ---- OPEN-QUANT-Q8: the same q8 tensor streamed AT q8, through q8_perm
@@ -266,6 +280,125 @@ void mixed_container_tests() {
     check(msg.find("mlp.down_proj.weight") != std::string::npos && msg.find("5120") != std::string::npos &&
               msg.find("8704") != std::string::npos,
           "q8_perm over a q4_1 tensor is refused, naming it (\"" + msg + "\")");
+
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+}
+
+// ---- OPEN-QUANT-Q4K: a Q4_K source (4736-byte chunks, what FLM 1.0.3+ writes)
+constexpr size_t Q4K_CH = 4736;
+const char* Q4K_NAME = "model.layers.0.mlp.gate_proj.weight";
+
+/// The Q4_K test vector specs/open-engine/tests/test_quant_q4k.py builds byte for byte:
+/// per chunk one LCG seeded from the chunk index; 4608 plain bytes (uint8 scales, uint8
+/// mins, nibbles), then 32 bf16 `S` with exponent 0x76 and 32 bf16 `M` with the same
+/// exponent and the sign bit set -- a Q4_K min is stored already negated.
+std::vector<uint8_t> q4k_vector(size_t nch) {
+    std::vector<uint8_t> out(nch * Q4K_CH);
+    for (size_t c = 0; c < nch; ++c) {
+        uint32_t s = 0x9E3779B9u * static_cast<uint32_t>(c + 1);
+        uint8_t* p = out.data() + c * Q4K_CH;
+        for (size_t i = 0; i < 4608; ++i) {
+            s = s * 1664525u + 1013904223u;
+            p[i] = static_cast<uint8_t>(s >> 24);
+        }
+        for (size_t i = 0; i < 32; ++i) {
+            s = s * 1664525u + 1013904223u;
+            const uint16_t h = static_cast<uint16_t>(0x3B00u | (s >> 24));
+            std::memcpy(p + 4608 + 2 * i, &h, 2);
+        }
+        for (size_t i = 0; i < 32; ++i) {
+            s = s * 1664525u + 1013904223u;
+            const uint16_t h = static_cast<uint16_t>(0xBB00u | (s >> 24));
+            std::memcpy(p + 4672 + 2 * i, &h, 2);
+        }
+    }
+    return out;
+}
+
+/// A Q4_K chunk's value at (row, block, lane), read straight off the layout rather than
+/// through the transcode: value = S[r]*scales[b*32+r]*nib + M[r]*mins[b*32+r]. The two
+/// terms come back separately because each is rounded once by the transcode, so the error
+/// bound is 2^-8 * (|scale term| + |min term|) -- and where the two cancel, that is much
+/// larger than 2^-8 * |value|.
+std::pair<double, double> q4k_terms(const uint8_t* chunk, unsigned r, unsigned b, unsigned i) {
+    auto f32 = [](uint16_t h) {
+        uint32_t u = static_cast<uint32_t>(h) << 16;
+        float f;
+        std::memcpy(&f, &u, 4);
+        return static_cast<double>(f);
+    };
+    uint16_t sh, mh;
+    std::memcpy(&sh, chunk + 4608 + 2 * r, 2);
+    std::memcpy(&mh, chunk + 4672 + 2 * r, 2);
+    const unsigned k = b * 32 + i;
+    const uint8_t byte = chunk[512 + k * 16 + r / 2];
+    const unsigned nib = (r % 2) ? (byte >> 4) : (byte & 0xF);
+    return {nib * f32(sh) * chunk[b * 32 + r], f32(mh) * chunk[256 + b * 32 + r]};
+}
+
+void q4k_container_tests() {
+    const std::vector<uint8_t> q4k = q4k_vector(NCH);
+    const std::vector<uint8_t> q4 = lcg_bytes(0x1234567u, NCH * Q4_CH);
+    const std::vector<uint8_t> bad = lcg_bytes(0x89ABCDEu, NCH * BAD_CH);
+    const std::string path = write_container("open_qwen36_pools_test_q4k",
+                                             {{Q4K_NAME, Q4K_CH, &q4k}, {Q4_NAME, Q4_CH, &q4}, {BAD_NAME, BAD_CH, &bad}});
+    open_qwen36::Q4nxFile f(path);
+    check(f.chunk_bytes(Q4K_NAME) == Q4K_CH, "a Q4_K tensor's chunk width is read per tensor");
+
+    // the transcode itself: the reading is the container's value up to the bf16 rounding of
+    // the two products -- a half-ulp each, 2^-8 relative
+    std::vector<uint8_t> tr(NCH * Q4_CH);
+    q4k_to_q4_1_chunks(q4k.data(), NCH, tr.data());
+    double worst = 0.0;
+    bool moved = false;
+    for (size_t c = 0; c < NCH; ++c)
+        for (unsigned r = 0; r < 32; ++r)
+            for (unsigned b = 0; b < 8; ++b)
+                for (unsigned i = 0; i < 32; ++i) {
+                    const auto t = q4k_terms(q4k.data() + c * Q4K_CH, r, b, i);
+                    const double want = t.first + t.second;
+                    const double got = q4_read(tr.data() + c * Q4_CH, r, b, i);
+                    const double tol = (0x1p-8 + 0x1p-20) * (std::abs(t.first) + std::abs(t.second));
+                    worst = std::max(worst, std::abs(got - want) / (tol + 1e-300));
+                    moved = moved || got != want;
+                }
+    check(worst <= 1.0, "q4k_to_q4_1: within a bf16 half-ulp of the container's value (worst " +
+                            std::to_string(worst) + " x the bound)");
+    check(moved, "q4k_to_q4_1: the rounding is really exercised");
+
+    const uint64_t gott = fnv1a(tr.data(), tr.size());
+    std::printf("      q4k transcode fnv1a = 0x%016llx\n", static_cast<unsigned long long>(gott));
+    check(gott == Q4K_TRANSCODE_FNV1A, "q4k_to_q4_1: byte-identical to the NumPy transcode");
+
+    // as a pack source: the permutation is applied to transcoded chunks, exactly as to
+    // file chunks, and a q4_1 tensor beside it is still a verbatim copy
+    std::vector<uint8_t> pool(2 * NCH * Q4_CH, 0);
+    open_qwen36::pools::apply(std_perm_op(Q4K_NAME, 0), f, 0, pool.data(), pool.size(), Q4_CH);
+    open_qwen36::pools::apply(std_perm_op(Q4_NAME, NCH * Q4_CH), f, 0, pool.data(), pool.size(), Q4_CH);
+    const auto perm = band_perm(NCH, IN_DIM);
+    bool okk = true, ok4 = true;
+    for (size_t c = 0; c < NCH && okk; ++c)
+        okk = std::memcmp(pool.data() + c * Q4_CH, tr.data() + perm[c] * Q4_CH, Q4_CH) == 0;
+    check(okk, "std_perm: a Q4_K source packs as the transcoded q4_1, same chunk order");
+    for (size_t c = 0; c < NCH && ok4; ++c)
+        ok4 = std::memcmp(pool.data() + (NCH + c) * Q4_CH, q4.data() + perm[c] * Q4_CH, Q4_CH) == 0;
+    check(ok4, "std_perm: a q4_1 source beside a Q4_K one is still copied chunk for chunk");
+
+    const uint64_t got = fnv1a(pool.data(), pool.size());
+    std::printf("      q4k pool fnv1a = 0x%016llx\n", static_cast<unsigned long long>(got));
+    check(got == Q4K_POOL_FNV1A, "Q4_K / q4_1 pool: byte-identical to the NumPy packer");
+
+    // a kernel set that streams this projection at q8 is not satisfied by Q4_K
+    std::string msg;
+    try {
+        open_qwen36::pools::apply(q8_perm_op(Q4K_NAME, 0), f, 0, pool.data(), pool.size(), Q4_CH);
+    } catch (const std::exception& e) {
+        msg = e.what();
+    }
+    check(msg.find("mlp.gate_proj.weight") != std::string::npos && msg.find("4736") != std::string::npos &&
+              msg.find("8704") != std::string::npos,
+          "q8_perm over a Q4_K tensor is refused, naming it (\"" + msg + "\")");
 
     std::error_code ec;
     std::filesystem::remove(path, ec);
@@ -341,6 +474,7 @@ int main() {
 
     // ---- a container mixing q8 and q4_1 tensors, packed through pools::apply
     mixed_container_tests();
+    q4k_container_tests();
 
     std::printf("%s (%d failures)\n", failures ? "FAIL" : "PASS", failures);
     return failures ? 1 : 0;

--- a/utilities/q4nx-build/configs/qwen3.5_0.8b.json
+++ b/utilities/q4nx-build/configs/qwen3.5_0.8b.json
@@ -62,8 +62,7 @@
     },
     "up_proj": {
       "gguf_name": "blk.{bid}.ffn_up.weight",
-      "q4nx_name": "model.layers.{bid}.mlp.up_proj.weight",
-      "default_tensor_type": "Q8_0"
+      "q4nx_name": "model.layers.{bid}.mlp.up_proj.weight"
     },
     "gate_proj": {
       "gguf_name": "blk.{bid}.ffn_gate.weight",

--- a/utilities/q4nx-build/q4nx/cli.py
+++ b/utilities/q4nx-build/q4nx/cli.py
@@ -88,6 +88,12 @@ def _parse_args(argv):
         "--flm-version", dest="flm_version", default=None, help="flm_version to write into config.json"
     )
     parser.add_argument(
+        "--quant", dest="quant", default=None, choices=["Q4_0", "Q4_1", "Q8_0", "Q4_K"],
+        help="Override the family config's default weight format. Q4_K is the 4736-byte "
+             "super-block layout FLM 1.0.3+ requires for the 35B MoE projections; the "
+             "configs still default to what each family has shipped.",
+    )
+    parser.add_argument(
         "-d", "--deploy", dest="deploy_tag", default=None, metavar="NAME:SIZE",
         help="Deploy the converted model into flm's models dir and register it under this tag (e.g. 'qwen3.5-claude:9b')",
     )
@@ -270,6 +276,8 @@ def main(argv=None) -> int:
     if hf_input is not None:
         model = create_hf_converter(hf_input, args.force_model_type)
         model.pad_to_fit = args.pad_to_fit
+        if args.quant:
+            model.set_default_tensor_type(args.quant)
         if weights_type == "vision":
             model.convert(q4nx_path=output_folder, weights_type="language")
             model.convert(q4nx_path=output_folder, weights_type="vision")
@@ -287,6 +295,8 @@ def main(argv=None) -> int:
     else:
         model = create_converter(input_path, args.force_model_type)
         model.pad_to_fit = args.pad_to_fit
+        if args.quant:
+            model.set_default_tensor_type(args.quant)
         if weights_type == "vision":
             model.convert(q4nx_path=output_folder, weights_type="language")
             model.convert(q4nx_path=output_folder, weights_type="vision")

--- a/utilities/q4nx-build/q4nx/gguf_tensor.py
+++ b/utilities/q4nx-build/q4nx/gguf_tensor.py
@@ -9,12 +9,102 @@ from dataclasses import dataclass
 from mpmath.libmp import int_types
 import numpy as np
 import torch
+import torch.nn.functional as F
+from einops import rearrange
+
+
+def _round_up(n: int, multiple: int) -> int:
+    """utils.round_up_to_multiple, inlined: this module is also loaded on its own, by
+    file path, so it must not reach into the package (specs/open-engine/tests)."""
+    return n if multiple == 0 else ((n + multiple - 1) // multiple) * multiple
+
+def _to_bf16_up(x: np.ndarray) -> np.ndarray:
+    """Round the magnitude of a non-negative float32 UP to a BF16 value."""
+    u = np.ascontiguousarray(x, dtype=np.float32).view(np.uint32)
+    r = np.where(u & np.uint32(0xFFFF), np.uint32(0x10000), np.uint32(0))
+    return ((u + r) & np.uint32(0xFFFF0000)).view(np.float32)
+
+
+def _bf16_next_up(x: np.ndarray, n: int) -> np.ndarray:
+    """The n-th BF16 value above a BF16-representable, non-negative x (n=0 is x)."""
+    if n == 0:
+        return np.asarray(x, dtype=np.float32)
+    u = np.ascontiguousarray(x, dtype=np.float32).view(np.uint32)
+    return (u + np.uint32(n) * np.uint32(0x10000)).view(np.float32)
+
+
+def _refit_one_side(t: np.ndarray, search: int = 3,
+                    cap: float = 255.0) -> Tuple[np.ndarray, np.ndarray]:
+    """Fit one metadata side of a super-block: exact per-group t_j -> (BF16 P', uint8 p'_j).
+
+    Direct port of the pseudocode in quant.md, "Re-fitting (uint6, FP16) into
+    (uint8, BF16)".  The kernel only ever uses the product t_j = P * p_j, so the
+    caller hands over exactly that -- Q4_K's (FP16 P, uint6 p_j) collapsed into a
+    single exact float32 -- and this preserves it directly.
+
+    The two extra bits of p'_j are spent *absorbing* P's rounding error rather
+    than as a plain x4 (which would be a no-op, since P/4 has P's significand):
+    P' is fixed first, rounded away from zero so p'_j can never overflow the cap,
+    then each p'_j is re-derived against the rounded P'.  Since t_j / P' runs up
+    to 255, the quotient can absorb up to 255 * 2^-8 ~ 1 integer step, which the
+    uint8 grid -- 4x finer than the uint6 grid it came from -- can represent.
+
+    `search` also tries that many BF16 values above the base P' and keeps
+    whichever minimizes sum_j (P' p'_j - t_j)^2.  A slightly larger P' often
+    aligns better with several t_j at once than the smallest admissible one, and
+    it is what removes the re-fit's sensitivity to how spread the t_j are; 3 is
+    the knee of the measured sweep.
+
+    Parameters
+    ----------
+    t : np.ndarray
+        Effective per-group scale (or min), shape (..., groups_per_super_block),
+        exact in float32.
+    search : int
+        Number of extra BF16 candidates above the base P' to score.
+    cap : float
+        Largest representable p'_j (255 for uint8).
+
+    Returns
+    -------
+    Tuple[np.ndarray, np.ndarray]
+        P' (BF16-representable float32, shape t.shape[:-1]) and p'_j (float32
+        integers in [0, cap], shape of t).  Effective value: P' p'_j ~ t_j.
+    """
+    t = np.ascontiguousarray(t, dtype=np.float32)
+    tmax = np.abs(t).max(axis=-1)
+    # p'_j is unsigned, so the sign rides on P'; take it from the largest entry
+    # (Q4_K's d/dmin are non-negative, so every t_j in a group shares one sign).
+    lead = np.take_along_axis(t, np.argmax(np.abs(t), axis=-1)[..., None], axis=-1)[..., 0]
+    sigma = np.where(lead < 0, np.float32(-1.0), np.float32(1.0))
+    t = sigma[..., None] * t
+    live = tmax > 0                                              # dead super-block -> all zero
+    base = _to_bf16_up(tmax / np.float32(cap))
+
+    best_P = np.zeros_like(base)
+    best_p = np.zeros_like(t)
+    best_e = np.full(base.shape, np.inf, dtype=np.float64)
+    for c in range(search + 1):
+        Pc = np.where(live, _bf16_next_up(base, c), np.float32(0.0)).astype(np.float32)
+        inv = np.where(live, 1.0 / np.where(live, Pc, np.float32(1.0)), np.float32(0.0)).astype(np.float32)
+        pc = np.clip(np.rint(t * inv[..., None]), 0.0, cap).astype(np.float32)
+        err = np.sum((Pc[..., None] * pc - t).astype(np.float64) ** 2, axis=-1)
+        take = err < best_e
+        best_e = np.where(take, err, best_e)
+        best_P = np.where(take, Pc, best_P)
+        best_p = np.where(take[..., None], pc, best_p)
+
+    return (sigma * best_P).astype(np.float32), best_p
+
 
 class GGUFTensor:
     name: str
     shape: Tuple[int, ...]
     data: np.ndarray
     tensor_type: GGMLQuantizationType
+
+    # Q4_K shares one uint6 scale/min per 32 weights, 8 of them per 256-weight super-block.
+    Q4_K_GROUP_SIZE = 32
 
     def __init__(self, name: str, shape: Tuple[int, ...], data: np.ndarray, tensor_type: GGMLQuantizationType):
         self.name = name
@@ -74,6 +164,85 @@ class GGUFTensor:
 
         return d, m, qs
     
+    @staticmethod
+    def unpack_q4_k(tensor: np.ndarray, columns: int) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Unpack GGML Q4_K into per-group effective scale / min plus the raw uint4 quants.
+
+        A Q4_K block is 144 bytes covering 256 weights = 8 groups of 32:
+
+            2 B   d      FP16 super-block scale S
+            2 B   dmin   FP16 super-block min   M
+            12 B  scales 8 uint6 s_j + 8 uint6 m_j, bit-packed (get_scale_min_k4)
+            128 B qs     256 uint4 q, nibble-packed
+
+        and dequantizes as w^j_i = (S s_j) q^j_i - (M m_j): the min is an unsigned
+        magnitude that is *subtracted*, unlike Q4_1's signed +m.
+
+        What comes back here is the *factored-out* form t_j = S s_j and u_j = M m_j,
+        one pair per group of 32, held exactly in float32 (11-bit FP16 significand
+        times a 6-bit integer needs 17 bits, so the product is exact).  Nothing is
+        re-quantized and no super-block structure survives, which means the result
+        has the same shape and the same 32-column granularity as unpack_q4_1's
+        (d, m, qw) and can go through the model-specific row/column reorders
+        untouched.  The (BF16 S', uint8 s'_j) re-fit of quant.md happens later, in
+        _pack_q4k, over whichever 8 groups actually end up sharing a super-block
+        after those reorders.
+
+        Parameters
+        ----------
+        tensor : np.ndarray
+            Raw Q4_K tensor bytes.
+        columns : int
+            Row length K; must be a multiple of 256.
+
+        Returns
+        -------
+        Tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+            t (rows, K/32), u (rows, K/32), q (rows, K), all float32.  u is the
+            unsigned magnitude that is *subtracted*: w = t_j q - u_j.
+        """
+        block_size, type_size = GGML_QUANT_SIZES[GGMLQuantizationType.Q4_K]
+        assert columns % block_size == 0, "Columns must be divisible by the Q4_K super-block size"
+        data = tensor.view(np.uint8)
+        n_blocks = data.size // type_size
+        blocks = data.reshape((n_blocks, type_size))
+
+        d, rest = np.hsplit(blocks, [2])
+        dmin, rest = np.hsplit(rest, [2])
+        scales, qs = np.hsplit(rest, [12])
+
+        S = d.view(np.float16).astype(np.float32).reshape(n_blocks)
+        M = dmin.view(np.float16).astype(np.float32).reshape(n_blocks)
+
+        # get_scale_min_k4: groups 0..3 take a plain 6-bit field, groups 4..7 take
+        # a low nibble from scales[j+4] plus the two high bits of scales[j-4].
+        lo = scales[:, 0:4]      # j = 0..3
+        hi = scales[:, 4:8]      # j = 4..7 for the min side, high bits for j = 4..7
+        top = scales[:, 8:12]
+        s6 = np.concatenate([lo & np.uint8(0x3F),
+                             (top & np.uint8(0x0F)) | ((lo >> np.uint8(6)) << np.uint8(4))], axis=1)
+        m6 = np.concatenate([hi & np.uint8(0x3F),
+                             (top >> np.uint8(4)) | ((hi >> np.uint8(6)) << np.uint8(4))], axis=1)
+        s6 = s6.astype(np.float32)
+        m6 = m6.astype(np.float32)
+
+        # qs holds four runs of 32 bytes; within a run the low nibbles are the
+        # first group of 32 and the high nibbles the next one.
+        qb = qs.reshape((n_blocks, 4, 32))
+        q = np.stack([qb & np.uint8(0x0F), qb >> np.uint8(4)], axis=2)  # (nb, 4, 2, 32)
+        q = q.reshape((n_blocks, block_size)).astype(np.float32)
+
+        # Exact in float32: 11-bit significand x 6-bit integer fits in 24 bits.
+        t = (S[:, None] * s6).astype(np.float32)
+        u = (M[:, None] * m6).astype(np.float32)
+
+        n_groups = int(columns // GGUFTensor.Q4_K_GROUP_SIZE)
+        t = torch.from_numpy(t).contiguous().view(-1, n_groups)
+        u = torch.from_numpy(u).contiguous().view(-1, n_groups)
+        q = torch.from_numpy(q).contiguous().view(-1, int(columns))
+
+        return t, u, q
+
     @staticmethod
     def unpack_q8_0(tensors:np.ndarray, columns:int):
         """Split GGML Q8_0 data into scales and quantized values
@@ -251,6 +420,11 @@ class GGUFTensor:
             return self._requantize_to(default_tensor_type)
         elif self.tensor_type == GGMLQuantizationType.MXFP4:
             return self.unpack_mxfp4(self.data, self.shape[0])
+        elif self.tensor_type == GGMLQuantizationType.Q4_K:
+            # Read natively. Stacking a dequantize onto a re-quantize costs 0.240 bits of
+            # ENOB and 0.375 bpw against this path, and damages the tail far more than the
+            # mean; q5/q6 still take the fallback below.
+            return self.unpack_q4_k(self.data, self.shape[0])
         else:
             """
                 If the tensor type is not natively packable as-is (either a
@@ -277,6 +451,16 @@ class GGUFTensor:
     def _requantize_to(self, default_tensor_type: GGMLQuantizationType) -> np.ndarray:
         """Dequantize the source tensor and re-quantize it into the requested
         target format, returning a (d, m, qw) tuple ready for packing."""
+        # ggml has no Q4_K encoder, so a source that has to go through a re-quantize
+        # (q5/q6, or a float tensor) lands on Q4_1's grid. A real Q4_K source never
+        # reaches here -- `unpack` reads it natively. The caller still packs Q4_K, and
+        # the two disagree on the sign of the min: Q4_1 stores an added `m` (<= 0), Q4_K
+        # a subtracted magnitude `u` (>= 0). Negating it below is exact and keeps the
+        # tuple in the convention the packer the caller will use expects; without it the
+        # weights come out silently mirrored about the block minimum.
+        want_q4_k = default_tensor_type == GGMLQuantizationType.Q4_K
+        if want_q4_k:
+            default_tensor_type = GGMLQuantizationType.Q4_1
         try:
             w = dequantize(self.data, self.tensor_type)
             w = torch.from_numpy(w).contiguous().to(torch.bfloat16)
@@ -297,7 +481,7 @@ class GGUFTensor:
                 d, m, qw = self.unpack_q8_0(data_quantized, self.shape[0])
             else:
                 raise ValueError(f"Unsupported tensor type: {default_tensor_type.name}")
-            return d, m, qw
+            return (d, -m, qw) if want_q4_k else (d, m, qw)
         except Exception as e:
             print(
                 f"[WARN] Could not quantize {self.tensor_type.name} tensor "
@@ -312,3 +496,97 @@ class GGUFTensor:
                 return [w]
             except Exception:
                 return None, None, None
+
+
+def pack_q4k(t: torch.Tensor, u: torch.Tensor, q: torch.Tensor, row_block_size: int,
+             col_block_size: int, keep_block_in_2D: bool, search: int = 3) -> torch.Tensor:
+    """Pack the FLM q4_k format (uint8 s'/m' per group + bf16 S'/M' per super-block).
+
+    Input is what GGUFTensor.unpack_q4_k returns, *after* any model-specific
+    reorder: the effective per-group scale t_j and subtracted min u_j in exact
+    float32, shape (rows, cols // 32), plus the uint4 quants (rows, cols).  The
+    (BF16 P', uint8 p'_j) re-fit of quant.md is done here, per 256-column
+    super-block, so it always fits the 8 groups that really share a super-block
+    in the packed output -- a reorder that shuffles columns at a granularity
+    finer than 256 (ssm_out_proj moves 128-column chunks) would otherwise leave
+    the super-block metadata unrepresentable.
+
+    Upstream (ROCm FLM_Q4NX_Converter, `_Q4NX_Converter._pack_q4k`) reads the block
+    geometry off the converter; here it is three arguments, so the packer can be loaded
+    and checked on its own -- specs/open-engine/tests/test_quant_q4k.py holds it against
+    the engine's reader (OPEN-QUANT-Q4K).
+
+    Mirrors `q4k_block_t` in the decoding kernels' model_spec.h, one struct
+    per row_block_size x col_block_size chunk, everything column major over
+    the chunk (the whole row span is resident at once, so there is no
+    parallel-strided re-order):
+
+        uint8 scales[col_block_size // Q4_group_size][row_block_size]
+        uint8 mins  [col_block_size // Q4_group_size][row_block_size]
+        uint4 qs    [col_block_size][row_block_size // NUM_int4_in_byte]
+        bf16  S     [col_block_size // Q4K_super_block_size][row_block_size]
+        bf16  M     [col_block_size // Q4K_super_block_size][row_block_size]
+
+    With the shipping 32x256 chunk that is 256 + 256 + 4096 + 64 + 64 = 4736 B,
+    i.e. 4.625 bits per weight, matching get_quantization_byte_size().
+
+    GGUF's Q4_K subtracts the min (w = S' s'_j q - M' m'_j) while the kernel
+    adds both accumulators, so M' is stored negated here.
+    """
+    Q4_group_size = 32
+    Q4K_super_block_size = 256
+    NUM_int4_in_byte = 2
+
+    t = t.to(torch.float32).contiguous()
+    u = u.to(torch.float32).contiguous()
+    q = q.contiguous()
+
+    cols = q.shape[-1]
+    assert cols % Q4K_super_block_size == 0, "Q4_K needs a multiple of 256 columns"
+    assert col_block_size % Q4K_super_block_size == 0
+
+    if cols % col_block_size != 0:
+        cols_padded = _round_up(cols, col_block_size)
+        t = F.pad(t, (0, (cols_padded - cols) // Q4_group_size), "constant", 0)
+        u = F.pad(u, (0, (cols_padded - cols) // Q4_group_size), "constant", 0)
+        q = F.pad(q, (0, cols_padded - cols), "constant", 0)
+
+    # Re-fit each side onto (BF16 super-block value, uint8 per-group value).
+    groups_per_super = Q4K_super_block_size // Q4_group_size
+    S, s8 = _refit_one_side(t.numpy().reshape(-1, groups_per_super), search=search)
+    M, m8 = _refit_one_side(u.numpy().reshape(-1, groups_per_super), search=search)
+    S = torch.from_numpy(S).view(t.shape[0], -1)
+    M = torch.from_numpy(M).view(u.shape[0], -1)
+    s8 = torch.from_numpy(s8).view_as(t)
+    m8 = torch.from_numpy(m8).view_as(u)
+
+    # scales / mins: one group of 32 columns contributes row_block_size uint8,
+    # groups ascending -- the same block layout the bf16 scales use in q4nx.
+    s8 = rearrange(s8, '(p r) (u c) -> p u (c r)', r=row_block_size,
+                   c=col_block_size // Q4_group_size).contiguous()
+    m8 = rearrange(m8, '(p r) (u c) -> p u (c r)', r=row_block_size,
+                   c=col_block_size // Q4_group_size).contiguous()
+    # S / M: one entry per row per super-block; a 256-column chunk holds exactly one.
+    S = rearrange(S, '(p r) (u c) -> p u (c r)', r=row_block_size,
+                  c=col_block_size // Q4K_super_block_size).contiguous()
+    M = rearrange(M, '(p r) (u c) -> p u (c r)', r=row_block_size,
+                  c=col_block_size // Q4K_super_block_size).contiguous()
+
+    # quants: one column = row_block_size nibbles, rows paired into a byte with
+    # the even row in the low nibble, columns ascending.
+    q = rearrange(q, '(p r) (u c) -> p u r c', r=row_block_size, c=col_block_size)
+    q = rearrange(q, 'p u (r b) c -> p u c r b', b=NUM_int4_in_byte).contiguous().to(torch.int8)
+    q[..., 1] = torch.bitwise_and(torch.bitwise_left_shift(q[..., 1], 4), 0xF0)
+    q[..., 0] = torch.bitwise_or(torch.bitwise_and(q[..., 0], 0x0F), q[..., 1])
+    q = rearrange(q[..., 0].contiguous(), 'p u c r -> p u (c r)').contiguous()
+
+    s8 = s8.to(torch.uint8).view(torch.int8).numpy()
+    m8 = m8.to(torch.uint8).view(torch.int8).numpy()
+    S = S.to(torch.bfloat16).view(torch.int8).numpy()
+    M = (-M).to(torch.bfloat16).view(torch.int8).numpy()   # kernel adds the min path
+    q = q.view(torch.int8).numpy()
+
+    merged = torch.from_numpy(np.concatenate([s8, m8, q, S, M], axis=-1).copy())
+    if not keep_block_in_2D:
+        merged = merged.reshape(-1, merged.shape[-1])
+    return merged

--- a/utilities/q4nx-build/q4nx/model_converter.py
+++ b/utilities/q4nx-build/q4nx/model_converter.py
@@ -11,7 +11,7 @@ from .arch_detect import (
     resolve_override_candidates,
 )
 from .constants import nearest_qwen35_variant
-from .gguf_tensor import GGUFTensor, GGMLQuantizationType
+from .gguf_tensor import GGUFTensor, GGMLQuantizationType, pack_q4k
 from typing import List, Dict, Type
 import os
 import json
@@ -124,6 +124,8 @@ class __Q4NX_Converter(ABC):
             self.default_tensor_type = GGMLQuantizationType.Q4_1
         elif self.q4nx_config["default_tensor_type"] == "Q8_0":
             self.default_tensor_type = GGMLQuantizationType.Q8_0
+        elif self.q4nx_config["default_tensor_type"] == "Q4_K":
+            self.default_tensor_type = GGMLQuantizationType.Q4_K
         else:
             raise ValueError("Unsupported default_tensor_type in config")
         
@@ -142,6 +144,21 @@ class __Q4NX_Converter(ABC):
             self.audio_MM_N = None
         self._create_name_maps()
 
+    def set_default_tensor_type(self, q4nx_name: str) -> None:
+        """Override the config's `default_tensor_type` after it is loaded (the CLI's
+        `--quant`). Roles that pin their own type in the config keep it; everything else
+        follows, so the name maps are rebuilt. `Q4_K` is what FLM 1.0.3+ requires for the
+        35B MoE projections -- q4_1 there decodes as infinite `////` or segfaults."""
+        if q4nx_name == "Q4_K" and self.gguf_reader is None:
+            raise ValueError(
+                "--quant Q4_K needs a GGUF source. The HF-safetensors path quantizes with "
+                "its own fixed per-role targets (_store_q), so it would write a q4_1 "
+                "container while claiming Q4_K. Convert from the family's GGUF instead."
+            )
+        self.q4nx_config["default_tensor_type"] = q4nx_name
+        self.default_tensor_type = self.get_ggml_type(q4nx_name)
+        self._create_name_maps()
+
     def get_ggml_type(self, q4nx_name: str) -> GGMLQuantizationType:
         if q4nx_name == "Q4_0":
             return GGMLQuantizationType.Q4_0
@@ -149,6 +166,8 @@ class __Q4NX_Converter(ABC):
             return GGMLQuantizationType.Q4_1
         elif q4nx_name == "Q8_0":
             return GGMLQuantizationType.Q8_0
+        elif q4nx_name == "Q4_K":
+            return GGMLQuantizationType.Q4_K
         elif q4nx_name == "BF16":
             return GGMLQuantizationType.BF16
         else:
@@ -584,7 +603,13 @@ class __Q4NX_Converter(ABC):
             
             
     def _pack(self, d: torch.Tensor, m: torch.Tensor = None, qw: torch.Tensor = None, tensor_type: GGMLQuantizationType = None) -> torch.Tensor:
-        if tensor_type == GGMLQuantizationType.Q8_0:
+        if tensor_type == GGMLQuantizationType.Q4_K:
+            # Same shapes as Q4_1, different semantics: d and m are the effective per-group
+            # scale t_j and *subtracted* min u_j, and the super-block re-fit happens inside
+            # pack_q4k. Dispatch is by type.
+            return pack_q4k(d, m, qw, self.row_block_size, self.col_block_size,
+                            self.keep_block_in_2D)
+        elif tensor_type == GGMLQuantizationType.Q8_0:
             # Q8NX format: scale array (d, bf16) followed by int8 data, no min
             # array. This matches the official Q8_0-packed tensors (alpha/beta/
             # out_proj/lm_head) which use 8704-byte chunks (256 blocks x 34).


### PR DESCRIPTION
This answers the one item left open on #17 ("decide about Q4_K"): the open
engine can now read the weight format the newer FLM builds write, so the five models in `model_list.json` that use it
stop being off-limits — including the 35B this engine is named after.

**The short version.** There are two weight layouts in circulation. The engine
read the older one (q4_1, what FLM 1.0.2 wrote) and refused the newer one (Q4_K,
1.0.3+). It now reads both. Nothing in the kernels changed, and no kernel needs
rebuilding.

That turned out to be much less work than the earlier plan assumed. Q4_K stores
a scale and an offset for each row and each group of 32 columns — the same
grouping the engine's own layout already uses, and in the same order. So loading
a Q4_K model is two multiplications per weight and a byte shuffle, done once
while the weights are being laid out for the NPU. The kernels never see the
difference. The earlier plan expected to teach them a second decoder and worried
about fitting it in the cores' 16 KB of program memory; none of that is needed.

**What it costs.** Weights land 0.48% off in RMS terms, measured across every
Q4_K tensor of a real model. For comparison, the engine already re-quantizes q8
weights down to q4_1 on this same path, and that costs 8%. So this is the more
accurate of the two conversions the packer does, by a wide margin.

**The converter can also write the format**, via `q4nx-build --quant Q4_K`. That
is the part I'd most like a second opinion on — see the question at the end.

**How it was checked.** Thirteen unit tests, run on both sides of the
Python/C++ boundary and required to agree byte for byte, so the reference
implementation and the engine cannot drift apart. Then a real model: a
Qwen3.5-0.8B fine-tune converted twice from one GGUF, once to each format, so
the weights are identical and the format is the only variable. Both load through
`flm serve` on the open kernels and answer coherently under `flm-test`. At
temperature 0 they produce the same answer, word for word, until they pick
different phrasing for the same claim partway through the second sentence.
Speed is the same within noise.

`flm-test --tools` fails 5 of its 6 checks on the Q4_K model — and fails the same
5 identically on the q4_1 twin. That is a 0.8B model that does not emit tool
calls, not a format problem, but it will show up in the CSV so it is worth saying
plainly.

**One unrelated fix rode along.** `configs/qwen3.5_0.8b.json` marked the
`up_proj` weights as q8 while the model Atomic-Germ actually ships stores them as
q4_1, and the other three qwen3.5 sizes never marked it. The kernel exporter
refuses a model whose feed-forward weights are split across two formats, so
*every* 0.8B container this converter produced failed to export — at the old
format exactly as much as at the new one. Unpinning it matches both the shipped
model and the sibling configs. It is one line, and without it the verification
above cannot be run at all.

**What I'd like from you.** The writer is the part I am least sure about. No
model on Hugging Face or in the registry ships Q4_K yet, so the only container it
has ever been tested against is one it produced itself. That is unavoidable for
now — you cannot test a reader without a writer — but it does mean the reader is
checked against our own writer rather than against FLM's. If the struct moves
again in a future FLM, this catches nothing. What it does guarantee is that a
mismatch shows up as a refusal naming the byte width, never as silently wrong
weights.

So: is shipping the writer the right call now, or would you rather it waited for
a real Q4_K model to check against?

Background, in more detail than belongs here:
`specs/open-engine/plans/archive/q4k-containers.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
