### PR TITLE
Open engine: say which kernel set was chosen, and why

### DIFF
--- a/src/open_qwen36/engine.cpp
+++ b/src/open_qwen36/engine.cpp
@@ -25,7 +25,8 @@ namespace open_qwen36 {
 
 namespace fs = std::filesystem;
 
-std::string Engine::find_kernels(const LM_Config& config) {
+std::string Engine::find_kernels(const LM_Config& config, std::string* how) {
+    auto chose = [how](const char* where) { if (how) *how = where; };
     // A kernel set is a manifest.json plus every xclbin / insts.bin it names.
     auto complete = [](const fs::path& dir, std::string* why) {
         std::error_code ec;
@@ -42,11 +43,11 @@ std::string Engine::find_kernels(const LM_Config& config) {
     };
     std::string why;
     if (const char* env = std::getenv("OFLM_OPEN_KERNELS_DIR")) {
-        if (complete(env, &why)) return env;
+        if (complete(env, &why)) { chose("OFLM_OPEN_KERNELS_DIR"); return env; }
         std::fprintf(stderr, "open_qwen36: OFLM_OPEN_KERNELS_DIR=%s is not a kernel set: %s\n", env, why.c_str());
     }
     fs::path local = fs::path(config.model_path) / "open_kernels";
-    if (complete(local, &why)) return local.string();
+    if (complete(local, &why)) { chose("beside the model"); return local.string(); }
     // Every xclbins root the closed path would consider, not just the first one
     // find_xclbin_path() happens to return: oflm-add links a set under the user
     // root ($OFLM_XCLBIN_PATH / ~/.config/oflm) while the shipped sets live in the
@@ -60,20 +61,27 @@ std::string Engine::find_kernels(const LM_Config& config) {
     }
     for (const std::string& r : roots) {
         fs::path cand = fs::path(r) / "xclbins" / config.model_name / "open_kernels";
-        if (complete(cand, &why)) return cand.string();
+        if (complete(cand, &why)) { chose("an xclbins root"); return cand.string(); }
     }
     return {};
 }
 
 Engine::Engine(const LM_Config& config, oflm_rt::device* dev, int MAX_L) : dev_(dev) {
     cfg_.model_dir = config.model_path;
-    cfg_.kernel_dir = find_kernels(config);
+    std::string how;
+    cfg_.kernel_dir = find_kernels(config, &how);
     if (cfg_.kernel_dir.empty())
         throw std::runtime_error("open_qwen36: no open kernels found for " + config.model_name +
                                  " (set OFLM_OPEN_KERNELS_DIR or install xclbins/" + config.model_name + "/open_kernels)");
     cfg_.max_ctx = MAX_L > 0 ? static_cast<size_t>(MAX_L) : 4096;
     if (const char* tm = std::getenv("OFLM_OPEN_TIMEOUT_MS")) cfg_.timeout_ms = static_cast<unsigned>(std::strtoul(tm, nullptr, 10));
     cfg_.verbose = std::getenv("OFLM_OPEN_QUIET") == nullptr;
+    // Say which set won. Three rules can pick one, and every one of them yields
+    // valid output -- so a set chosen against the user's intent looks exactly
+    // like the right one. An A/B that silently ran identical kernels twice, and
+    // read as "no measurable effect", is what this line exists to prevent (#35).
+    if (cfg_.verbose)
+        std::fprintf(stderr, "open_qwen36: kernels %s (%s)\n", cfg_.kernel_dir.c_str(), how.c_str());
     core_ = std::make_unique<Core>(cfg_, dev_);
     logits_.assign(core_->vocab(), bf16(0.f));
 }

--- a/src/open_qwen36/engine.hpp
+++ b/src/open_qwen36/engine.hpp
@@ -58,7 +58,10 @@ public:
     /// find_xclbin_path() happens to return first. A kernel set is a manifest.json
     /// plus the files it names. Empty when none is found — the caller then keeps
     /// the closed engine.
-    static std::string find_kernels(const LM_Config& config);
+    /// Resolve the kernel set. `how`, when given, receives which rule won.
+    /// The caller logs it: a silently-chosen set produces perfectly valid
+    /// output from kernels the user did not mean to run (#35).
+    static std::string find_kernels(const LM_Config& config, std::string* how = nullptr);
 
     const Core& core() const { return *core_; }
 


### PR DESCRIPTION
Addresses #35, in part — see the correction at the end.

The engine resolves its kernel set by one of three rules and never says which
won. All three produce valid output, so a set chosen against the user's intent
looks exactly like the right one: an A/B measurement here silently ran identical
kernels twice and read as "no measurable effect", when the real difference was
1.7×.

It now prints the resolved directory and the rule that picked it:

```
open_qwen36: kernels .../Granite-4.2-3B-NPU2/open_kernels (beside the model)
```

**Correcting the issue.** #35 says the model-adjacent directory outranks the
environment variables. That is true of `FLM_XCLBIN_PATH`, which is only
consulted after it — but **not** of `FLM_OPEN_KERNELS_DIR`, which
`find_kernels()` already checks first and already warns about when it is set and
invalid. I wrote the issue too broadly.

So this changes no precedence. The silence is what made the failure expensive,
and it is the half worth fixing on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
