### PR TITLE
Build: name the binary oflm, not flm

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -412,6 +412,13 @@ endif()
 
 add_executable(flm ${SOURCES} ${HEADERS})
 
+# The file on disk is `oflm`, not `flm` (#8). A binary named `flm` is
+# ambiguous on PATH wherever FastFlowLM is also installed, and the wrong
+# one answering makes its errors look like ours -- a missing flag rather
+# than a different program. The CMake TARGET stays `flm` so that every
+# reference below is unchanged; only the output name moves.
+set_target_properties(flm PROPERTIES OUTPUT_NAME oflm)
+
 if(WIN32)
     if(VCPKG_TOOLCHAIN)
         # A vcpkg toolchain is active (e.g. the rocm-npu-staging dev.py build or
@@ -707,27 +714,28 @@ endif()
 
 
 # ———————————————————————————————————————————————
-# Copy the build flm.exe into the out directory (for local dev)
+# Copy the built executable into the out directory (for local dev)
 # ———————————————————————————————————————————————
 if(WIN32)
     add_custom_command(TARGET flm POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy
             $<TARGET_FILE:flm>
-            ${CMAKE_SOURCE_DIR}/out/flm.exe
+            ${CMAKE_SOURCE_DIR}/out/$<TARGET_FILE_NAME:flm>
     )
 
-    # AND THE ENGINE DLLs BESIDE IT, or a freshly built flm.exe cannot start
+    # AND THE ENGINE DLLs BESIDE IT, or a freshly built oflm.exe cannot start
     # -- and fails in a way that sends you looking in the wrong place.
     #
     # The 22 *_npu.dll / q4_npu_eXpress.dll / gemm.dll / dequant.dll live in
     # src/lib/<backend>/ and are load-time imports, so without them the process
     # dies at 0xC0000135 (DLL not found) BEFORE main(), printing nothing.
     # Windows then falls through to the next PATH entry -- which on a machine
-    # with FastFlowLM installed is C:/Program Files/flm/flm.exe. So
+    # with FastFlowLM installed was C:/Program Files/flm/flm.exe -- so
     # `flm.exe serve ... --embeddingmodel x` run from the build directory
-    # reports "unrecognised option", from a completely different binary than
-    # the one you just built. The symptom names a flag; the cause is a
-    # missing DLL two steps earlier.
+    # reported "unrecognised option", from a completely different binary
+    # than the one you just built. Renaming to oflm (#8) removes that
+    # particular confusion, but the DLLs are still load-time imports and
+    # the process still dies before main() without them.
     #
     # Both destinations are gitignored build trees, so this copies nothing
     # into the repository and redistributes nothing: it puts the files this
@@ -735,7 +743,7 @@ if(WIN32)
 
     # AND THE MODEL CATALOGUE, for the same reason. utils.cpp looks for
     # model_list.json next to the executable (after FLM_CONFIG_PATH), and
-    # nothing put one there, so a freshly built flm.exe stops at
+    # nothing put one there, so a freshly built oflm.exe stops at
     #
     #   model_list.json not found. Please set FLM_CONFIG_PATH or place it
     #   next to the executable.
@@ -753,7 +761,7 @@ if(WIN32)
             ${CMAKE_SOURCE_DIR}/model_list.json
             ${CMAKE_SOURCE_DIR}/model_info.json
             ${CMAKE_SOURCE_DIR}/out
-        COMMENT "Copying model_list.json / model_info.json beside flm.exe"
+        COMMENT "Copying model_list.json / model_info.json beside $<TARGET_FILE_NAME:flm>"
     )
 
     file(GLOB FLM_RUNTIME_DLLS "${CMAKE_SOURCE_DIR}/lib/${FLM_RUNTIME_NAME}/*.dll")
@@ -763,7 +771,7 @@ if(WIN32)
                 ${FLM_RUNTIME_DLLS} $<TARGET_FILE_DIR:flm>
             COMMAND ${CMAKE_COMMAND} -E copy_if_different
                 ${FLM_RUNTIME_DLLS} ${CMAKE_SOURCE_DIR}/out
-            COMMENT "Copying ${FLM_RUNTIME_NAME} engine DLLs beside flm.exe"
+            COMMENT "Copying ${FLM_RUNTIME_NAME} engine DLLs beside $<TARGET_FILE_NAME:flm>"
         )
     endif()
 

--- a/src/build-windows-vcpkg.cmd
+++ b/src/build-windows-vcpkg.cmd
@@ -1,5 +1,5 @@
 @echo off
-REM Configure + build flm.exe on Windows with MSVC and a vcpkg toolchain.
+REM Configure + build oflm.exe on Windows with MSVC and a vcpkg toolchain.
 REM
 REM This is the path that worked on a bare box (2026-09-05): no standalone
 REM Boost b2 build, no hand-copied import libs — every native dependency comes
@@ -57,12 +57,12 @@ if errorlevel 1 exit /b 1
 REM Stage a runnable tree in out\ (what the Makefile's `run` target does, plus
 REM the vcpkg runtime DLLs).
 if not exist out mkdir out
-copy /y build\flm.exe out\ >nul
+copy /y build\oflm.exe out\ >nul
 copy /y lib\xrt\*.dll out\ >nul
 copy /y lib\*.dll out\ >nul
 copy /y "%VCPKG_ROOT%\installed\x64-windows\bin\*.dll" out\ >nul
 copy /y model_list.json out\ >nul
 copy /y model_info.json out\ >nul
 xcopy /e /i /y /q xclbins out\xclbins >nul
-echo [flm] OK -^> out\flm.exe   (set FLM_MODEL_PATH=%%USERPROFILE%%\.flm from a non-interactive shell)
+echo [flm] OK -^> out\oflm.exe   (set FLM_MODEL_PATH=%%USERPROFILE%%\.flm from a non-interactive shell)
 exit /b 0

--- a/src/home_install.sh
+++ b/src/home_install.sh
@@ -56,7 +56,7 @@ fi
 # ---- install into the home prefix -----------------------------------------
 # This runs the same install rules as a system install, just relocated.
 # It populates:
-#   $FLM_PREFIX/bin/flm
+#   $FLM_PREFIX/bin/oflm
 #   $FLM_PREFIX/lib/flm/*.so
 #   $FLM_PREFIX/share/flm/model_list.json
 #   $FLM_PREFIX/share/flm/xclbins/
@@ -81,7 +81,7 @@ XRT_DIR="$XRT_DIR"
 export FLM_CONFIG_PATH="\$FLM_PREFIX/share/flm/model_list.json"
 export FLM_XCLBIN_PATH="\$FLM_PREFIX/share/flm"
 
-# 2. Runtime libraries. The flm binary already has RPATH \$ORIGIN/../lib/flm for
+# 2. Runtime libraries. The oflm binary already has RPATH \$ORIGIN/../lib/flm for
 #    its bundled .so files, but XRT's libs (libxrt_coreutil.so, etc.) are found
 #    via XRT's own setup or LD_LIBRARY_PATH.
 if [[ -f "\$XRT_DIR/setup.sh" ]]; then

--- a/src/inno/flm.iss
+++ b/src/inno/flm.iss
@@ -45,7 +45,7 @@ UninstallDisplayIcon={app}\logo.ico
 
 ; Main executable
 
-Source: "flm.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "oflm.exe"; DestDir: "{app}"; Flags: ignoreversion
 
 ; Required DLL
 
@@ -104,17 +104,17 @@ Source: "..\xclbins\*"; DestDir: "{app}\xclbins"; Flags: ignoreversion recursesu
 
 [Icons]
 
-Name: "{group}\flm"; \
-    Filename: "{app}\flm.exe"; \
+Name: "{group}\oflm"; \
+    Filename: "{app}\oflm.exe"; \
     WorkingDir: "{app}"; \
     IconFilename: "{app}\logo.ico"; \
     IconIndex: 0; \
-    Comment: "Launch flm"
+    Comment: "Launch oflm"
 
 ; Desktop shortcut (conditional based on user choice)
 Name: "{commondesktop}\flm run"; \
     Filename: "{sys}\cmd.exe"; \
-    Parameters: "/K ""{app}\flm.exe"" run llama3.2:1b"; \
+    Parameters: "/K ""{app}\oflm.exe"" run llama3.2:1b"; \
     WorkingDir: "{app}"; \
     IconFilename: "{app}\logo.ico"; \
     IconIndex: 0; \
@@ -125,7 +125,7 @@ Name: "{commondesktop}\flm run"; \
 ; Desktop shortcut (conditional based on user choice)
 Name: "{commondesktop}\flm serve"; \
     Filename: "{sys}\cmd.exe"; \
-    Parameters: "/K ""{app}\flm.exe"" serve"; \
+    Parameters: "/K ""{app}\oflm.exe"" serve"; \
     WorkingDir: "{app}"; \
     IconFilename: "{app}\logo.ico"; \
     IconIndex: 0; \


### PR DESCRIPTION
Fixes #8.

The binary is now `oflm` (`oflm.exe` on Windows). A binary named `flm` is
ambiguous on PATH wherever FastFlowLM is also installed, and when the wrong one
answers, its errors read as ours — `flm.exe serve … --embeddingmodel x`
reporting "unrecognised option" from a different program entirely.

The CMake target stays `flm`, so only the file on disk moves and every
`$<TARGET_FILE:flm>` reference is unaffected. The vcpkg build script,
`home_install.sh` and the Inno installer's shortcuts follow it. Directory names
(`share/flm`, `lib/flm`, `~/.flm`) and the `FLM_*` environment variables are
deliberately untouched — those are install layout and contract, not the
executable.

Built and run: `[8/8] Linking CXX executable oflm.exe`, and `oflm --version`
starts.

**What it does not do.** `oflm --version` still prints `FLM v1.0.4`, so a bug
report still cannot say which codebase produced it — the ambiguity raised in the
#8 thread. That is #33.

Name picked from the thread: @Atomic-Germ proposed `oflm`, and @Cyronius called
it "fine as the exe name" while preferring something more distinctive overall.
If the project lands on a different name later this is a one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
