### PR TITLE
Docs: a README about this project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,148 +1,105 @@
 <p align="center">
-  <a href="https://www.fastflowlm.com" target="_blank">
-    <img src="assets/logo.png" alt="FastFlowLM Logo" width="200"/>
-  </a>
-</p>
-
-<p align="center">
   <img src="https://img.shields.io/badge/NPU-Optimized-red" />
 </p>
 
-## ⚡ FastFlowLM (FLM) — Unlock Ryzen™ AI NPUs
+## OpenFlowLM — open NPU kernels for Ryzen™ AI
 
-Run large language models — now with **Vision**, **Audio**, **Embedding** and **MoE** support — on **AMD Ryzen™ AI NPUs** in minutes.  
-**No GPU required. Faster and over 10× more power-efficient. Supports context lengths up to 256k tokens. Ultra-Lightweight (17 MB). Installs within 20 seconds.**
+A community fork of [FastFlowLM](https://github.com/ROCm/FastFlowLM) that
+replaces the closed NPU kernels with open ones, built from source in this
+repository.
 
-📦 **The only out-of-box, NPU-first runtime built exclusively for Ryzen™ AI.**  
-🤝 **A familiar single-command CLI — deeply optimized for NPUs.**  
-✨ **From Idle Silicon to Instant Power — FastFlowLM Makes Ryzen™ AI Shine.**
+Run LLMs, embedding models and MoE models on **AMD Ryzen™ AI NPUs** — no GPU
+required.
 
-> FastFlowLM (FLM) supports all Ryzen™ AI Series chips with XDNA2 NPUs (Strix, Strix Halo, Kraken, and Gorgon Point).
-
----
-
-## 🔗 Quick Links
-
-  🔽 **[Download](https://github.com/ROCm/FastFlowLM/releases/latest/download/flm-setup.msi)** | 📊 **[Benchmarks](https://fastflowlm.com/docs/benchmarks/)** | 📦 **[Model List](https://fastflowlm.com/docs/models/)**  
-
-  🐧 **[Linux Getting Started Guide](./docs/linux-getting-started.md)**
-
-  📖 **[Docs](https://fastflowlm.com/docs)** | 📺 **[Demos](https://www.youtube.com/playlist?list=PLf87s9UUZrJoDdz639Yc6w1UTyJ4cFHZ1)** | 💬 **[Discord](https://discord.gg/z24t23HsHF)** 
+> Supports Ryzen™ AI chips with XDNA2 NPUs (Strix, Strix Halo, Kraken and
+> Gorgon Point).
 
 ---
 
-## 🚀 Quick Start
+## What is different from upstream
 
-A packaged FLM Windows installer is available here: [**flm-setup.msi**](https://github.com/ROCm/FastFlowLM/releases/latest/download/flm-setup.msi). For more details, see the [release notes](https://github.com/ROCm/FastFlowLM/releases/).
+- **Open kernels.** `open_kernels/` holds the AIE designs the engine
+  dispatches — source, not pre-compiled binaries. Seven model families run on a
+  shared recipe that works each model's shape out of its own `config.json`.
+- **A second embedding backend.** Six encoder models beyond the one upstream
+  ships, through [`src/open_npue/`](src/open_npue/).
+- **GGUF and Q4_K containers**, so models are not confined to one weight format.
+- **Built from source.** There is no packaged installer here; see
+  [docs/BUILD.md](docs/BUILD.md).
 
-📺 [**Watch the quick start video (Windows)**](https://www.youtube.com/watch?v=mYOfDNkyBII)
+Upstream remains the place to go for a turnkey install and for the closed,
+tuned kernels.
 
-> [!IMPORTANT]  
-> ⚠️ Use the **latest** AMD NPU driver — **32.0.203.311 or above** (check via Task Manager→Performance→NPU or Device Manager). Earlier versions are no longer supported.  
-> ⚙️ **Tip:**
->   * **RECOMMENDED**: Try running **Windows Update** or **[Driver Download](https://www.amd.com/en/support)**.
->   * **[Official AMD Install Doc](https://ryzenai.docs.amd.com/en/latest/inst.html#install-npu-drivers)** *(AMD account required)*.
->   * **[Unofficial forum downloads](https://www.elevenforum.com/t/drivers-amd-npu-ryzen-8xxx-9xxx-apu.24220/)** *(CAUTION: third-party content not verified by AMD; download and use at your own risk)*.
+---
 
-After installation, open **PowerShell** (`Win + X → I`). To run a model in terminal (**CLI Mode**):
-```powershell
-flm run llama3.2:1b
+## Getting started
+
+1. **The NPU driver** — use **32.0.203.311 or above** (Task Manager →
+   Performance → NPU, or Device Manager). Earlier versions are not supported.
+   Windows Update or [AMD's driver download](https://www.amd.com/en/support) is
+   the recommended route; the
+   [official install doc](https://ryzenai.docs.amd.com/en/latest/inst.html#install-npu-drivers)
+   has the details.
+
+2. **Build it** — [docs/BUILD.md](docs/BUILD.md). There are two things to
+   build: the executable, and the AIE design sets the NPU actually runs. The
+   design sets are not checked in, and without them the binary starts and then
+   refuses to load a model.
+
+3. **Run it:**
+
+   ```powershell
+   oflm run llama3.2:1b
+   ```
+
+   or serve an OpenAI-compatible API:
+
+   ```powershell
+   oflm serve
+   ```
+
+🐧 [Linux getting-started guide](./docs/linux-getting-started.md)
+
+---
+
+## Highlights
+
+- **Runs on the NPU** — not the GPU, and not as CPU fallback
+- **Open kernel path** — the designs are here, and rebuilding them is a
+  documented step rather than a vendor drop
+- **Long context** — up to 256k tokens on models that support it
+- **Familiar CLI** — `run`, `serve`, `list`, `bench`
+
+---
+
+## License
+
+- Orchestration code and CLI tools are open source under the
+  [MIT License](./LICENSE_RUNTIME.txt).
+- The open AIE kernels in `open_kernels/` are part of this repository and carry
+  its licence.
+- Any closed binary kernels retained from upstream remain FastFlowLM's, under
+  the terms upstream sets, and are not redistributed by this repository.
+
+If you build on this work, an acknowledgement of both projects is appreciated:
+
 ```
-> **Notes:**
-> - Internet access to HuggingFace is required to download the optimized model kernels.
-> - Sometimes downloads from HuggingFace may get corrupted. If this happens, run `flm pull <model_tag> --force` (e.g. `flm pull llama3.2:1b --force`) to re-download and fix them.
-> - By default, models are stored in:
->   - **Windows**: `C:\Users\<USER>\.flm\models\`
->   - **Linux**: `~/.config/flm/`
-> - During installation on Windows, you can select a different base folder (e.g., if you choose `C:\Users\<USER>\flm`, models will be saved under `C:\Users\<USER>\flm\models\`).
-> - On Linux, you can override the default location by setting the `FLM_MODEL_PATH` environment variable.
-> - To disable the startup version check, set `FLM_DISABLE_UPDATE_CHECK=1`.
-> - ⚠️ If HuggingFace is not accessible in your region, manually download the model ([check this issue](https://github.com/ROCm/FastFlowLM/issues/2)) and place it in the chosen directory.   
-
-🎉🚀 FastFlowLM (FLM) is ready — your NPU is unlocked and you can start chatting with models right away!
-
-Open **Task Manager** (`Ctrl + Shift + Esc`). Go to the **Performance** tab → click **NPU** to monitor usage.  
-
-> **⚡ Quick Tips:**  
-> - Use `/verbose` during a session to turn on performance reporting (toggle off with `/verbose` again).   
-> - Type `/bye` to exit a conversation.  
-> - Run `flm list` in PowerShell to show all available models.  
-
-To start the local server (**Server Mode**):
-```powershell
-flm serve llama3.2:1b
+Powered by OpenFlowLM, a fork of FastFlowLM
 ```
-> The model tag (e.g., `llama3.2:1b`) sets the initial model, which is optional. If another model is requested, FastFlowLM will automatically switch to it. The local server runs on port 52625 (default).  
-
-**[![FastFlowLM Docs](https://img.shields.io/badge/FastFlowLM-Detailed%20Instructions-red?style=flat&logo=readthedocs)](https://fastflowlm.com/docs/instructions/)**
 
 ---
 
-## 📰 In the News
+## Acknowledgements
 
-- 08/11/2026 🎉 FLM is now part of **[ROCm](https://github.com/ROCm/FastFlowLM)** (v1.0.0) — the repo has moved to AMD's open-source ROCm organization.
-
-- 08/11/2026 🎉 FLM releases its first **SmolVLA** model (v1.0.0) — a Vision-Language-Action robotics policy running on the NPU. See the **[model card](https://fastflowlm.com/docs/models/smolvla/)** and **[benchmarks](https://fastflowlm.com/docs/benchmarks/smolvla_results/)**.
-
-- 07/17/2026 🎉 FLM is now part of AMD **[news](https://www.amd.com/en/blogs/2026/fastflowlm-joins-amd-to-advance-ai-inference.html)**. Read **[our story](./flm_story.md)** — from a 2025 university project to AMD.
-
-- 03/11/2026 🎉 FLM now supports Linux 🐧 ! To get started, check out the **[quick start guide](https://fastflowlm.com/docs/install_lin/)** or the **[Lemonade Server docs](https://lemonade-server.ai/flm_npu_linux.html)**, and watch the **[short video](https://www.youtube.com/watch?v=tXRchP3sKA8)** for a quick walkthrough of FLM on Linux via Lemonade 🍋.
-
-- 10/01/2025 🎉 FLM was integrated into AMD's **[Lemonade Server](https://lemonade-server.ai/)** 🍋. Watch this **[short demo](https://www.youtube.com/watch?v=w0Tb3h4WUnE)** about using FLM in Lemonade.
-
----
-
-## 🧠 Local AI on NPU
-
-FLM makes it easy to run cutting-edge **LLMs** (and now **VLMs**) locally with:
-- ⚡ Fast and low power
-- 🧰 Simple CLI and API (REST and OpenAI API)
-- 🔐 Fully private and offline
-
-No model rewrites, no tuning — it just works.
-
----
-
-## ✅ Highlights
-
-- **Runs fully on AMD Ryzen™ AI NPU** — no GPU or CPU load
-- **Lightweight runtime (17 MB)** — installs within **20 seconds**, easy to integrate    
-- **Developer-first flow** — a familiar single-command CLI, optimized for NPU  
-- **Support for long context windows** — up to 256k tokens (e.g., Qwen3-4B-Thinking-2507)  
-- **No low-level tuning required** — You focus on your app, we handle the rest
-
----
-
-## 📄 License
-
-- All orchestration code and CLI tools are open-source under the [MIT License](./LICENSE_RUNTIME.txt).  
-- These NPU-accelerated binary kernels are completely free for any use, including commercial use.
-- Please acknowledge FastFlowLM in your README/project page (or product) as follows:
-  ```
-  Powered by [FastFlowLM](https://github.com/ROCm/FastFlowLM)
-  ```
-  
----
-
-💬 Have **feedback/issues** or want **early access** to our new releases? [Open an issue](https://github.com/ROCm/FastFlowLM/issues/new) or [Join our Discord community](https://discord.gg/z24t23HsHF)
-
----
-
-## 🙏 Acknowledgements
-
-- Powered by the advanced **AMD Ryzen™ AI NPU architecture**
-- Inspired by the widely adopted [llama.cpp](https://github.com/ggml-org/llama.cpp) and [Ollama](https://github.com/ollama/ollama)
-- Tokenization accelerated with [MLC-ai/tokenizers-cpp](https://github.com/mlc-ai/tokenizers-cpp)
+- Forked from [FastFlowLM](https://github.com/ROCm/FastFlowLM)
+- Powered by the **AMD Ryzen™ AI NPU** architecture
+- Inspired by [llama.cpp](https://github.com/ggml-org/llama.cpp) and
+  [Ollama](https://github.com/ollama/ollama)
+- Tokenization via [MLC-ai/tokenizers-cpp](https://github.com/mlc-ai/tokenizers-cpp)
 - Chat formatting via [Google/minja](https://github.com/google/minja)
-- Low-level kernels optimized using the powerful [IRON](https://github.com/amd/iron)+[AIE-MLIR](https://github.com/Xilinx/mlir-aie)
+- Kernels written with [IRON](https://github.com/amd/iron) +
+  [MLIR-AIE](https://github.com/Xilinx/mlir-aie)
 
 ---
 
-## 🛠️ Building from Source
-
-**[docs/BUILD.md](docs/BUILD.md)** — a step-by-step guide for Windows and Linux.
-
-Note that there are **two** things to build: the executable, and the AIE design
-sets the NPU actually runs. The design sets are not checked in, they need a
-second toolchain, and without them the binary starts and then refuses to load a
-model. BUILD.md covers both.
+💬 [Open an issue](https://github.com/Atomic-Germ/OpenFlowLM-Next/issues/new)

--- a/README.md
+++ b/README.md
@@ -140,58 +140,9 @@ No model rewrites, no tuning — it just works.
 
 ## 🛠️ Building from Source
 
-For developers who want to build FastFlowLM from source, we provide CMake presets for a convenient and consistent build experience.
+**[docs/BUILD.md](docs/BUILD.md)** — a step-by-step guide for Windows and Linux.
 
-### Prerequisites
-
-- Git
-- CMake (version 3.22 or higher)
-- A C++20 compatible compiler (e.g., GCC, Clang, MSVC)
-- Ninja (recommended)
-
-### Build Instructions
-
-More details on the exact procedure, with dependencies to be installed, for Linux can be found in [linux-getting-started.md](docs/linux-getting-started.md).
-
-1.  **Clone the repository:**
-
-    ```bash
-    git clone --recursive https://github.com/ROCm/FastFlowLM.git
-    cd FastFlowLM/src
-    ```
-
-2.  **Configure CMake using presets:**
-
-    -   **For Linux:**
-
-        ```bash
-        cmake --preset linux-default
-        ```
-
-        This will configure the build to install to `/opt/fastflowlm`.
-
-    -   **For Windows (in a developer command prompt):**
-
-        ```bash
-        cmake --preset windows-default
-        ```
-
-3.  **Build the project:**
-
-    ```bash
-    cmake --build build
-    ```
-
-4.  **Install the project (optional):**
-
-    -   **For Linux:**
-
-        ```bash
-        sudo cmake --install build
-        ```
-
-    -   **For Windows (with administrator privileges):**
-
-        ```bash
-        cmake --install build
-        ```
+Note that there are **two** things to build: the executable, and the AIE design
+sets the NPU actually runs. The design sets are not checked in, they need a
+second toolchain, and without them the binary starts and then refuses to load a
+model. BUILD.md covers both.

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -1,0 +1,134 @@
+# Building from source
+
+**There are two things to build, and the executable alone is not enough.**
+
+| | what it is | without it |
+|---|---|---|
+| **the executable** | `oflm` (`oflm.exe` on Windows) | nothing to run |
+| **the AIE design sets** (`.xclbin` + `insts.bin`) | the NPU kernels the open engine dispatches | the binary starts and then **refuses to load a model**, naming the missing set |
+
+The design sets are **not** checked in — they are compiled from the sources in
+this repository, and building them needs a second toolchain (IRON / MLIR-AIE)
+that the executable's build does not use. This is the part that surprises
+people, so it comes first in every section below.
+
+---
+
+## 1. The executable
+
+### Prerequisites
+
+- Git, CMake ≥ 3.22, Ninja
+- a C++20 compiler — MSVC on Windows, GCC or Clang on Linux
+
+### Windows
+
+**Run it from a Visual Studio developer environment**, not a plain shell. The
+presets do not set the MSVC include paths themselves, and without them the
+build fails deep inside a vendored dependency on a missing `<cstdint>` — an
+error that names a third-party header and not the real cause.
+
+```powershell
+# a "x64 Native Tools Command Prompt", or in an existing shell:
+& "C:\Program Files\Microsoft Visual Studio\18\Community\VC\Auxiliary\Build\vcvars64.bat"
+
+cd src
+cmake --preset windows-default
+cmake --build build
+```
+
+The binary lands in `src/build/oflm.exe`, with `model_list.json`,
+`model_info.json` and the engine DLLs copied beside it by the build — it will
+not start without those, and Windows reports a missing DLL as a silent exit
+before `main()`.
+
+### Linux
+
+```bash
+cd src
+cmake --preset linux-default     # installs to /opt/fastflowlm
+cmake --build build
+sudo cmake --install build       # optional
+```
+
+`docs/setup.sh` installs the system dependencies, and
+[`linux-getting-started.md`](linux-getting-started.md) covers the driver and
+XRT side.
+
+Other presets: `linux-portable`, `linux-snap`, `windows-vs18`.
+
+---
+
+## 2. The AIE design sets
+
+Both kinds need the IRON toolchain **dot-sourced** into the shell first:
+
+```powershell
+cd C:\dev\mlir-aie; . .\iron_env.ps1        # the leading dot is required
+```
+
+On Linux, activate the equivalent `mlir-aie` virtualenv (`ironenv`), with
+`xclbinutil` and `aiebu-asm` on `PATH` — both come from XRT, not from the
+mlir-aie wheel.
+
+### Embedding models (`open_npue`)
+
+```powershell
+cd <repo>
+.\npu_offload\gemm_rtp\build.ps1
+```
+
+Five families, roughly 3–4 minutes each, so budget about 20 minutes. Already
+built families are skipped; `-Force` rebuilds and `-Only <name>` does one. The
+build flags live in `families.json`, not in the script — one machine-readable
+source, verified by `check_design_sets.py`.
+
+**Do not run two families concurrently.** The IRON build cache is shared and
+matches on content, so two families that share a geometry will delete each
+other's work; the script takes a lock and refuses rather than letting that
+happen.
+
+### LLM models (the open engine)
+
+```bash
+python open_kernels/export_qwen36_kernels.py [--model-dir DIR | --spec FILE] [--out DIR]
+```
+
+It derives the model's shape from its `config.json`, builds every kernel set
+the recipe names, and writes `final.xclbin` + `insts.bin` into
+`src/xclbins/<model>/open_kernels/` — where `src/open_qwen36/engine.cpp` looks
+for them. Beside them it writes `manifest.json` (everything the engine reads)
+and `toolchain.json` (the mlir-aie and Peano versions, this tree's git commit,
+and a sha256 per file, so a binary can be traced back to its source).
+
+`--only`, `--no-build`, `--force` and `--check DIR` are there for iterating on
+one set.
+
+---
+
+## 3. Check it works
+
+```
+oflm --version
+oflm list
+```
+
+The engine prints which kernel set it resolved when it loads a model:
+
+```
+open_qwen36: kernels .../<model>/open_kernels (beside the model)
+```
+
+Three rules can pick that directory — `FLM_OPEN_KERNELS_DIR`, then a set beside
+the model, then an `xclbins` root — and all three produce valid output. If you
+have just rebuilt kernels and want to be sure the new ones ran, read that line.
+
+---
+
+## Notes
+
+- The Windows and embedding-set instructions above were run on this repository;
+  the Linux presets and the LLM kernel export are transcribed from the build
+  scripts' own documented usage.
+- `~/.flm`, `share/flm`, `lib/flm` and the `FLM_*` environment variables keep
+  their names — those are install layout and contract, not the executable.


### PR DESCRIPTION
Fixes #7. Stacked on #42 — read that one first; until it merges the diff here includes it.

The README still described FastFlowLM. It pointed downloads at upstream's
installer, promised a 17 MB package that does not exist here, told readers to
run `flm`, and asked them to credit FastFlowLM for the kernels this fork
replaced with open ones.

It now says what this project is — a fork with open AIE kernels, a second
embedding backend, GGUF/Q4_K containers, built from source — and sends people to
[docs/BUILD.md](docs/BUILD.md) instead of a release page for a different
project. Upstream is credited as the parent and named as the place to go for a
turnkey install and the tuned closed kernels.

**Deliberately conservative in two places.** The licence section keeps its
structure (MIT for orchestration, the open kernels under this repository's
licence, retained closed kernels still upstream's and not redistributed here) —
licensing is not mine to restate. And no performance numbers are claimed, since
the ones in the old text were upstream's packaged build, not this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
