### PR TITLE
Finish the oflm rename: four places where the old name stopped being read

### DIFF
--- a/src/common/AutoModel/automodel.cpp
+++ b/src/common/AutoModel/automodel.cpp
@@ -37,8 +37,10 @@ std::string AutoModel::get_current_model() {
 std::unique_ptr<causal_lm> AutoModel::_shared_select_open_engine(const char* env_var, const std::string& family_label) {
 #ifdef OFLM_USE_OPEN_QWEN36
     const std::string kernels = open_qwen36::Engine::find_kernels(*this->lm_config);
-    const char* sel = std::getenv(env_var);
-    const bool use_open = sel ? std::string(sel) == "open" : !kernels.empty();
+    // getenv_oflm, not getenv: an install that predates the oflm rename still has the
+    // FLM_* name exported, and silently ignoring it would pick a different ENGINE (#41).
+    const std::string sel = utils::getenv_oflm(env_var);
+    const bool use_open = !sel.empty() ? sel == "open" : !kernels.empty();
     if (use_open && kernels.empty())
         throw std::runtime_error(std::string(env_var) + "=open but no open kernels were found for " + this->lm_config->model_name);
     if (!use_open)

--- a/src/common/AutoModel/modeling_qwen3_6_moe.cpp
+++ b/src/common/AutoModel/modeling_qwen3_6_moe.cpp
@@ -18,7 +18,7 @@ void Qwen3_6_MOE::load_model(std::string model_path, json model_info, int defaul
 
     // The engine: the open kernels when installed for this model, the closed
     // qwen3_6_moe_npu DLL otherwise. See AutoModel::_shared_select_open_engine.
-    auto open_engine = this->_shared_select_open_engine("FLM_QWEN36_ENGINE", "Qwen3.6-MoE");
+    auto open_engine = this->_shared_select_open_engine("OFLM_QWEN36_ENGINE", "Qwen3.6-MoE");
     if (open_engine) {
         this->lm_engine = std::move(open_engine);
     }

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -7,8 +7,10 @@
 /// \note This file contains some utility functions for the OpenFlowLM project.
 #include "utils/utils.hpp"
 #include <algorithm>
+#include <cstring>
 #include <filesystem>
 #include <cstdlib>
+#include <set>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -20,12 +22,44 @@
 
 namespace utils {
 
+std::string getenv_oflm(const char* oflm_name) {
+    if (const char* v = std::getenv(oflm_name)) {
+        if (*v) return std::string(v);
+    }
+    // "OFLM_FOO" -> "FLM_FOO". The rename dropped nothing else, so the inverse is
+    // to remove the leading 'O'; a name that is not OFLM_-prefixed has no legacy form.
+    if (std::strncmp(oflm_name, "OFLM_", 5) != 0) return std::string();
+    const std::string legacy = std::string("FLM_") + (oflm_name + 5);
+    const char* v = std::getenv(legacy.c_str());
+    if (!v || !*v) return std::string();
+    static std::set<std::string> warned;          // once per variable, not once per read
+    if (warned.insert(legacy).second) {
+        std::cerr << "[OFLM]  " << legacy << " is the name used before the oflm rename. "
+                  << "It still works; set " << oflm_name << " instead." << std::endl;
+    }
+    return std::string(v);
+}
+
+/// The user-level directories the pre-rename releases used, for the same reason
+/// user_oflm_directories() exists: a model store is gigabytes and must not have to
+/// move for an upgrade. Searched AFTER every oflm location, never before.
+std::vector<std::string> legacy_flm_directories() {
+    std::vector<std::string> v;
+#ifdef _WIN32
+    v.push_back((std::filesystem::path(get_user_directory()) / ".flm").string());
+    v.push_back((std::filesystem::path(get_user_directory()) / ".config" / "flm").string());
+#else
+    v.push_back(get_user_directory() + "/flm");
+#endif
+    return v;
+}
+
 std::string find_model_list() {
     std::string install_prefix = CMAKE_INSTALL_PREFIX;
 
     // 1. Check OFLM_CONFIG_PATH environment variable
-    const char* env_path = std::getenv("OFLM_CONFIG_PATH");
-    if (env_path && *env_path) {
+    const std::string env_path = getenv_oflm("OFLM_CONFIG_PATH");
+    if (!env_path.empty()) {
         if (std::filesystem::exists(env_path)) {
             std::cerr << "[OFLM]  Using custom model list path: " << env_path << std::endl;
             return env_path;
@@ -62,8 +96,8 @@ std::string find_model_info() {
     std::string install_prefix = CMAKE_INSTALL_PREFIX;
 
     // 1. Check OFLM_MODELINFO_PATH environment variable
-    const char* env_path = std::getenv("OFLM_MODELINFO_PATH");
-    if (env_path && *env_path) {
+    const std::string env_path = getenv_oflm("OFLM_MODELINFO_PATH");
+    if (!env_path.empty()) {
         if (std::filesystem::exists(env_path)) {
             std::cerr << "[OFLM]  Using custom model info path: " << env_path << std::endl;
             return env_path;
@@ -74,8 +108,8 @@ std::string find_model_info() {
     // install points OFLM_CONFIG_PATH at its own share/oflm; without this the
     // lookup falls through to the baked-in prefix below and we end up sizing
     // and hash-checking downloads against a different (stale) revision.
-    const char* config_path = std::getenv("OFLM_CONFIG_PATH");
-    if (config_path && *config_path) {
+    const std::string config_path = getenv_oflm("OFLM_CONFIG_PATH");
+    if (!config_path.empty()) {
         std::filesystem::path sibling =
             std::filesystem::path(config_path).parent_path() / "model_info.json";
         if (std::filesystem::exists(sibling)) {
@@ -129,22 +163,16 @@ std::string strip_xclbins(std::string path) {
     return path;
 }
 
-/// The user-level oflm directory oflm-add writes into: ~/.config/oflm on POSIX
-/// (get_user_directory() already ends in .config there) and <profile>/.config/oflm
-/// on Windows, which is where oflm-add's `Path.home() / ".config" / "oflm"` lands.
-std::string user_oflm_directory() {
-#ifdef _WIN32
-    return (std::filesystem::path(get_user_directory()) / ".config" / "oflm").string();
-#else
-    return get_user_directory() + "/oflm";
-#endif
-}
-
 /// The user-level directories for THIS project, newest first (#30). Returned as
 /// a list rather than a single path so that a directory made either way is
-/// found: #30 asks for %USERPROFILE%\.oflm on Windows, while flm-add's own
-/// `Path.home() / ".config" / <name>` would put it beside the flm one. Scanning
-/// both costs one stat.
+/// found: #30 asks for %USERPROFILE%\.oflm on Windows, while oflm-add's own
+/// `Path.home() / ".config" / <name>` lands in <profile>/.config/oflm. On POSIX
+/// get_user_directory() already ends in .config, so one entry covers it. Scanning
+/// them costs one stat each.
+///
+/// This list subsumes the former user_oflm_directory(), which the oflm rename left
+/// returning a path already in here -- dead code, and the reason nobody noticed the
+/// legacy root had stopped being searched (#41).
 std::vector<std::string> user_oflm_directories() {
     std::vector<std::string> v;
 #ifdef _WIN32
@@ -161,8 +189,8 @@ std::vector<std::string> user_oflm_directories() {
 /// path picks: it returns exactly one, and every closed kernel is loaded relative to it.
 std::vector<std::string> closed_path_roots() {
     std::vector<std::string> c;
-    const char* env_path = std::getenv("OFLM_XCLBIN_PATH");
-    if (env_path && *env_path) c.push_back(strip_xclbins(env_path));
+    const std::string env_path = getenv_oflm("OFLM_XCLBIN_PATH");
+    if (!env_path.empty()) c.push_back(strip_xclbins(env_path));
     std::string exe_dir = get_executable_directory();
     c.push_back(exe_dir);                       // portable development tree
     c.push_back(".");                           // then the CWD
@@ -179,19 +207,25 @@ std::vector<std::string> xclbin_roots() {
     // The user-level roots first: oflm-add installs a model's kernels under one of these,
     // and the shipped sets live in the install tree below. A lookup that stops at the
     // first root (find_xclbin_path) can only ever see one of the two.
-    const char* env_path = std::getenv("OFLM_XCLBIN_PATH");
-    if (env_path && *env_path) candidates.push_back(strip_xclbins(env_path));
+    const std::string env_path = getenv_oflm("OFLM_XCLBIN_PATH");
+    if (!env_path.empty()) candidates.push_back(strip_xclbins(env_path));
     // Beside an explicitly configured model_list.json, the way find_model_info stays
     // beside it: a user registry and its kernels live in one directory.
-    const char* config_path = std::getenv("OFLM_CONFIG_PATH");
-    if (config_path && *config_path) {
+    const std::string config_path = getenv_oflm("OFLM_CONFIG_PATH");
+    if (!config_path.empty()) {
         candidates.push_back(std::filesystem::path(config_path).parent_path().string());
     }
-    // The directories flm-add uses when neither variable is exported, new
+    // The directories oflm-add uses when neither variable is exported, new
     // before legacy (#30) -- an existing install keeps working with no
     // migration and no copying of multi-gigabyte weights.
+    //
+    // The second line used to be user_flm_directory(), i.e. the LEGACY root, and the
+    // oflm rename turned it into user_oflm_directory() -- a strict subset of the list
+    // above it. The line became dead and the legacy root stopped being searched, while
+    // the comment went on promising it. legacy_flm_directories() restores what the
+    // comment says (#41).
     for (const std::string& d : user_oflm_directories()) candidates.push_back(d);
-    candidates.push_back(user_oflm_directory());
+    for (const std::string& d : legacy_flm_directories()) candidates.push_back(d);
 
     for (const std::string& c : closed_path_roots()) candidates.push_back(c);
 
@@ -261,25 +295,9 @@ int get_server_port(int user_port) {
         return user_port;
     }
     else {
-#ifdef _WIN32
-        char* port_env = nullptr;
-        size_t len = 0;
-        if (_dupenv_s(&port_env, &len, "OFLM_SERVE_PORT") == 0 && port_env != nullptr) {
-            try {
-                int port = std::stoi(port_env);
-                free(port_env);
-                if (port > 0 && port <= 65535) {
-                    return port;
-                }
-            }
-            catch (const std::exception&) {
-                free(port_env);
-                // Invalid port number, use default
-            }
-        }
-#else
-        const char* port_env = std::getenv("OFLM_SERVE_PORT");
-        if (port_env && *port_env) {
+        // OFLM_SERVE_PORT, or the FLM_SERVE_PORT the pre-rename installer wrote (#41).
+        const std::string port_env = getenv_oflm("OFLM_SERVE_PORT");
+        if (!port_env.empty()) {
             try {
                 int port = std::stoi(port_env);
                 if (port > 0 && port <= 65535) {
@@ -290,7 +308,6 @@ int get_server_port(int user_port) {
                 // Invalid port number, use default
             }
         }
-#endif
     }
 
     return 52625; // Default port
@@ -299,29 +316,28 @@ int get_server_port(int user_port) {
 ///@brief get_models_directory gets the models directory from environment variable or defaults to user/.oflm/models on Windows or ~/.config/oflm on Linux
 ///@return the models directory path
 std::string get_models_directory() {
-#ifdef _WIN32
-    char* model_path_env = nullptr;
-    size_t len = 0;
-    if (_dupenv_s(&model_path_env, &len, "OFLM_MODEL_PATH") == 0 && model_path_env != nullptr) {
-        std::string custom_path(model_path_env);
-        free(model_path_env);
-        if (!custom_path.empty()) {
-            return custom_path;
-        }
-    }
-#else
-    const char* model_path_env = std::getenv("OFLM_MODEL_PATH");
-    if (model_path_env && *model_path_env) {
-        return std::string(model_path_env);
-    }
-#endif
-    // Fallback to user/.oflm/ on Windows or ~/.config/oflm on Linux if environment variable is not set
+    // OFLM_MODEL_PATH, or the FLM_MODEL_PATH the pre-rename installer wrote (#41).
+    const std::string custom_path = getenv_oflm("OFLM_MODEL_PATH");
+    if (!custom_path.empty()) return custom_path;
+
+    // No variable set: the oflm directory, then the pre-rename one if it exists and the
+    // oflm one does not. A model store is gigabytes; an upgrade must not orphan it.
     std::string user_dir = get_user_directory();
 #ifdef _WIN32
-    return user_dir + "\\.oflm";
+    const std::string oflm_dir = user_dir + "\\.oflm";
 #else
-    return user_dir + "/oflm";
+    const std::string oflm_dir = user_dir + "/oflm";
 #endif
+    std::error_code ec;
+    if (std::filesystem::is_directory(oflm_dir, ec)) return oflm_dir;
+    for (const std::string& d : legacy_flm_directories()) {
+        if (std::filesystem::is_directory(d, ec)) {
+            std::cerr << "[OFLM]  using the pre-rename model directory " << d
+                      << "; move it to " << oflm_dir << " when convenient." << std::endl;
+            return d;
+        }
+    }
+    return oflm_dir;
 }
 
 } // end of namespace utils

--- a/src/include/utils/utils.hpp
+++ b/src/include/utils/utils.hpp
@@ -392,4 +392,14 @@ int get_server_port(int user_port);
 ///@return the models directory path
 std::string get_models_directory();
 
+///@brief Read an OFLM_* environment variable, falling back to the FLM_* name the
+///       pre-rename releases (and their installer) wrote.
+///
+/// Every variable this project reads was renamed by prefixing an 'O', so one rule
+/// covers all of them. An install that predates the rename keeps working, and the
+/// legacy name is reported once per variable rather than silently honoured -- a
+/// migration that says nothing is indistinguishable from one that did not happen.
+///@return the value, or an empty string when neither name is set
+std::string getenv_oflm(const char* oflm_name);
+
 } // end of namespace utils

--- a/src/inno/oflm.iss
+++ b/src/inno/oflm.iss
@@ -227,36 +227,48 @@ function GetExistingModelPath: string;
 var
   ExistingPath: string;
 begin
-  // Check if OFLM_MODEL_PATH environment variable already exists
+  // OFLM_MODEL_PATH, if this machine has already run a post-rename installer.
   if RegQueryStringValue(HKEY_LOCAL_MACHINE,
     'SYSTEM\CurrentControlSet\Control\Session Manager\Environment',
-    'OFLM_MODEL_PATH', ExistingPath)
+    'OFLM_MODEL_PATH', ExistingPath) and (ExistingPath <> '')
   then begin
-    // OFLM_MODEL_PATH exists, use it as default
     Result := ExistingPath;
-  end
-  else begin
-    // OFLM_MODEL_PATH doesn't exist, use default userdocs location
-    Result := GetEnv('USERPROFILE') + '\.oflm';
+    Exit;
   end;
+  // Otherwise FLM_MODEL_PATH, which every installer before the oflm rename wrote (#41).
+  // Without this the wizard defaults to the profile's .oflm and points an upgrading
+  // user AWAY from a model store that is gigabytes -- silently, because nothing is
+  // deleted and nothing errors; the models simply stop being found.
+  if RegQueryStringValue(HKEY_LOCAL_MACHINE,
+    'SYSTEM\CurrentControlSet\Control\Session Manager\Environment',
+    'FLM_MODEL_PATH', ExistingPath) and (ExistingPath <> '')
+  then begin
+    Result := ExistingPath;
+    Exit;
+  end;
+  Result := GetEnv('USERPROFILE') + '\.oflm';
 end;
 
 function GetExistingPort: string;
 var
   ExistingPort: string;
 begin
-  // Check if OFLM_SERVE_PORT environment variable already exists
+  // OFLM_SERVE_PORT, then the pre-rename FLM_SERVE_PORT (#41), then the default.
   if RegQueryStringValue(HKEY_LOCAL_MACHINE,
     'SYSTEM\CurrentControlSet\Control\Session Manager\Environment',
-    'OFLM_SERVE_PORT', ExistingPort)
+    'OFLM_SERVE_PORT', ExistingPort) and (ExistingPort <> '')
   then begin
-    // OFLM_SERVE_PORT exists, use it as default
     Result := ExistingPort;
-  end
-  else begin
-    // OFLM_SERVE_PORT doesn't exist, use default port
-    Result := '52625';
+    Exit;
   end;
+  if RegQueryStringValue(HKEY_LOCAL_MACHINE,
+    'SYSTEM\CurrentControlSet\Control\Session Manager\Environment',
+    'FLM_SERVE_PORT', ExistingPort) and (ExistingPort <> '')
+  then begin
+    Result := ExistingPort;
+    Exit;
+  end;
+  Result := '52625';
   end;
 
 procedure InitializeWizard;

--- a/src/open_qwen36/engine.cpp
+++ b/src/open_qwen36/engine.cpp
@@ -175,7 +175,7 @@ buffer<bf16> Engine::prefill(std::vector<int>& ids, void* payload) {
     // same counter (Core::mrope_*), and later chunks / generated tokens inherit it.
     if (!core_->has_mrope() || core_->image_token_id() < 0)
         throw std::runtime_error("open_qwen36: config.json carries no image_token_id / mrope_section for this model; "
-                                 "images need the closed engine (FLM_QWEN36_ENGINE=closed)");
+                                 "images need the closed engine (OFLM_QWEN36_ENGINE=closed)");
     // The app hands its own family's payload struct (qwen3_6_moe_image_payload_t /
     // qwen3_5vl_image_payload_t -- the same fields); read it through the one matching the
     // kernel set's family.

--- a/src/pull/model_downloader.cpp
+++ b/src/pull/model_downloader.cpp
@@ -52,7 +52,28 @@ ModelDownloader::ModelStatus ModelDownloader::check_model_compatibility(const st
     LM_Config config;
     config.from_pretrained(this->supported_models.get_model_path(new_model_tag));
     std::string oflm_version = config.oflm_version;
-    std::string oflm_min_version = model_info["oflm_min_version"];
+    // oflm_min_version, or the flm_min_version that a registry written before the
+    // oflm rename carries (#41) -- the field was renamed in the DATA as well as the
+    // code, and nothing read the old name.
+    //
+    // An entry with neither is not a reason to abort. The implicit conversion this
+    // replaces threw `[json.exception.type_error.302] type must be string, but is
+    // null` straight out of check_model_compatibility, which `oflm list` calls once
+    // per entry -- so a single pre-rename or hand-written registry entry killed the
+    // ENTIRE listing, naming neither the model nor the field. Measured on a user
+    // registry carrying flm_min_version: 1 row printed, 39 lost, exit 1.
+    std::string oflm_min_version;
+    for (const char* key : {"oflm_min_version", "flm_min_version"}) {
+        auto it = model_info.find(key);
+        if (it != model_info.end() && it->is_string()) {
+            oflm_min_version = it->get<std::string>();
+            break;
+        }
+    }
+    // Nothing to compare against -- the same reasoning as the "0.0.0" case below.
+    if (oflm_min_version.empty()) {
+        return ModelStatus::Ready;
+    }
 
     // A CHECKPOINT THAT IS NOT AN OFLM ARTIFACT HAS NO VERSION TO COMPARE.
     //


### PR DESCRIPTION
The rename to `oflm` is done in main, so #41's original content — renaming the binary — is redundant. This replaces it. What is left are four places where a name changed and nothing reads the old one. Two of them fail silently.

**1. `FLM_QWEN36_ENGINE` was missed.** Every other selector is `OFLM_*`, and `src/open_qwen36/README.md` and `CMakeLists.txt:508` already document `OFLM_QWEN36_ENGINE`. Setting the documented name did nothing — no error, a different engine.

**2. The legacy user directory stopped being searched.** The rename turned `user_flm_directory()` into `user_oflm_directory()`, which is a strict subset of the `user_oflm_directories()` call on the line above — so the line became dead code while its own comment went on promising *"an existing install keeps working with no migration and no copying of multi-gigabyte weights"*. The dead duplicate is also why it was invisible. Removed it; `legacy_flm_directories()` restores the search the comment describes.

**3. No environment variable had a legacy fallback.** An install predating the rename has `FLM_MODEL_PATH` in its registry, and both the binary and the installer's own wizard pre-fill read only `OFLM_MODEL_PATH` — so the wizard defaults to `%USERPROFILE%\.oflm` and points an upgrading user away from a model store that is gigabytes. `getenv_oflm()` reads `OFLM_X` then `FLM_X` and reports once per variable which one it used; `oflm.iss` does the same for both values it pre-fills.

**4. The rename changed a field in the registry data as well.** `flm_min_version` became `oflm_min_version`, read by implicit conversion in `check_model_compatibility()`. A pre-rename registry therefore throws `[json.exception.type_error.302] type must be string, but is null` out of a function `oflm list` calls once per entry — so **one old entry kills the entire listing**, naming neither the model nor the field. It now accepts the legacy field, and treats "neither field present" as no constraint rather than as a reason to abort.

### Measured

On a user registry carrying `flm_min_version`:

| | rows listed | error |
|---|---:|---|
| before | 1 | `type_error.302`, exit 1 |
| after | 40 | none |

The repository's own post-rename registry is unchanged at 44 rows, before and after. Environment-variable behaviour checked in all four combinations: `OFLM_*` only, `FLM_*` only (value used, warned once), both (`OFLM_*` wins), neither.

### Not covered

The uninstaller still deletes only the `OFLM_*` registry values, so a machine that ran a pre-rename installer keeps its `FLM_*` ones behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCT7r8ebHia4kGAWsaKc3Y
