### PR TITLE
Gemma 4 tool calling: the tool result was reaching the model four tokens short

### DIFF
--- a/open_kernels/designs/lm_head_q4/lm_head_q4.py
+++ b/open_kernels/designs/lm_head_q4/lm_head_q4.py
@@ -102,7 +102,7 @@ def lm_head_q4(w: In, x: In, y: Out, *, n: CompileTime[int], k: CompileTime[int]
     i32 = np.int32
 
     inc = _include_dirs()
-    kernel = ExternalFunction("gemv_q4_gy", source_file=str(HERE / "gemv_q4_gy.cc"),
+    kernel = ExternalFunction("gemv_q4_gy", source_file=str(GY),
                               arg_types=[elem_ty, tab_ty, acc_ty, i32, i32, i32], include_dirs=inc, compile_flags=["-Os"])
     prep = ExternalFunction("gemv_q4_prep_rt", source_file=str(GEMV / "gemv_q4_prep_rt.cc"),
                             arg_types=[x_ty, tab_ty, i32, i32, i32], include_dirs=inc, compile_flags=["-Os"])
@@ -157,5 +157,5 @@ def lm_head_q4(w: In, x: In, y: Out, *, n: CompileTime[int], k: CompileTime[int]
 
 DESIGN = lm_head_q4
 _src = b"".join([(GEMV / f).read_bytes() for f in ("gemv_q4.h", "gemv_tab.h", "gemv_q4_prep_rt.cc")]
-                + [(HERE / "gemv_q4_gy.cc").read_bytes(), (HERE.parent.parent / "include" / "vecmath.h").read_bytes()])
+                + [GY.read_bytes(), (HERE.parent.parent / "include" / "vecmath.h").read_bytes()])
 SPECIALIZE = {"n": N, "k": K, "n_cores": N_CORES, "srchash": int(hashlib.sha1(_src).hexdigest()[:8], 16)}

--- a/specs/tool-calling/spec.md
+++ b/specs/tool-calling/spec.md
@@ -80,3 +80,23 @@ schema into its first non-null member, adding `nullable: true` when `null` was l
 - A schema without type arrays is returned unchanged.
 - A request whose tools include such a field succeeds through `oflm serve` and the
   model can call that tool (manual: `edge_cases.py` "nullable type array").
+
+## All models
+
+### TOOLS-REQUEST-PARAMS-RESET: request parameters do not leak between requests
+**Applies to:** openflowlm-next (`src/server/rest_handler.cpp`)
+**Test category:** integration (through `oflm serve`)
+**Test:** `specs/tool-calling/tests/test_request_params_reset.py`
+
+`temperature`, `top_p`, `top_k`, `min_p`, the penalties, `think` and `reasoning_effort`
+are applied to the engine only when a request carries them. The server shall restore the
+model's load-time defaults for those settings at the start of every chat request before
+applying the request's own fields, so a request that omits a field gets the model
+default and not whatever the previous request set.
+
+**Acceptance criteria:**
+- After a request with `reasoning_effort: "low"`, a request without the field on a
+  model whose default is no-think (Gemma 4) generates no reasoning content.
+- After a request with `temperature: 0`, a request without the field samples with the
+  model's default temperature (observable: the raw output no longer repeats bit for bit
+  across two identical prompts on a model whose default temperature is above 0).

--- a/specs/tool-calling/spec.md
+++ b/specs/tool-calling/spec.md
@@ -53,7 +53,9 @@ The model sometimes wraps the real call in a generic envelope whose outer name i
 `tool_call` (or `call`, `function`, `tool`, `function_call`) and whose arguments carry the
 real name under `id` or `name` and the real arguments under `args`, `arguments`,
 `parameters`, `params` or `input`. The parser shall return the inner name and inner
-arguments in that case, and leave every other call untouched.
+arguments in that case, and leave every other call untouched. Those outer names are legal
+tool names too, so a call only counts as an envelope when every one of its argument keys is
+one of the nine listed above; any other key means the call is real and is left alone.
 
 **Acceptance criteria:**
 - `call:tool_call{args:{query:"x"},id:<|"|>memory_search<|"|>}` parses to name
@@ -61,6 +63,9 @@ arguments in that case, and leave every other call untouched.
 - `call:function{name:<|"|>lookup_item_price<|"|>,arguments:{item:<|"|>widget<|"|>}}`
   parses to `lookup_item_price` / `{"item": "widget"}`.
 - `call:tool_call{query:<|"|>x<|"|>}` (no inner name) stays `tool_call` / `{"query": "x"}`.
+- `call:function{name:<|"|>widget<|"|>,quantity:2}` stays `function` /
+  `{"name": "widget", "quantity": 2}` — `quantity` is not an envelope key, so this is a
+  real tool named `function` and neither its name nor its arguments may be rewritten.
 - Direct calls, empty argument lists and nested object/array arguments parse as before.
 
 ### TOOLS-GEMMA4-SCHEMA-TYPES: a type array in a tool schema does not fail the request
@@ -84,19 +89,24 @@ schema into its first non-null member, adding `nullable: true` when `null` was l
 ## All models
 
 ### TOOLS-REQUEST-PARAMS-RESET: request parameters do not leak between requests
-**Applies to:** openflowlm-next (`src/server/rest_handler.cpp`)
+**Applies to:** openflowlm-next (`src/server/rest_handler.cpp`, `src/common/AutoModel/automodel.cpp`)
 **Test category:** integration (through `oflm serve`)
 **Test:** `specs/tool-calling/tests/test_request_params_reset.py`
 
-`temperature`, `top_p`, `top_k`, `min_p`, the penalties, `think` and `reasoning_effort`
-are applied to the engine only when a request carries them. The server shall restore the
-model's load-time defaults for those settings at the start of every chat request before
-applying the request's own fields, so a request that omits a field gets the model
-default and not whatever the previous request set.
+`temperature`, `top_p`, `top_k`, `min_p`, the penalties, `think`, `reasoning_effort` and
+`system_prompt` are applied to the engine only when a request carries them. The server
+shall restore the model's load-time defaults for those settings at the start of every
+chat request before applying the request's own fields, so a request that omits a field
+gets the model default and not whatever the previous request set. This holds for every
+model that accepts the setting, not only the Gemma 4 pair: `AutoModel` owns the thinking
+flag, the system prompt and the template's extra context, so its snapshot and reset cover
+all of them, and a model only overrides them for request state it keeps elsewhere.
 
 **Acceptance criteria:**
 - After a request with `reasoning_effort: "low"`, a request without the field on a
   model whose default is no-think (Gemma 4) generates no reasoning content.
+- The same holds on the other models that accept the field — Qwen 3, Qwen 3 MoE,
+  Qwen 3 VL and GPT-OSS — since none of them keeps the flag privately any more.
 - After a request with `temperature: 0`, a request without the field samples with the
   model's default temperature (observable: the raw output no longer repeats bit for bit
   across two identical prompts on a model whose default temperature is above 0).

--- a/specs/tool-calling/spec.md
+++ b/specs/tool-calling/spec.md
@@ -1,0 +1,82 @@
+# Tool calling through the OpenAI-compatible server
+
+The server layer that turns a model's native tool-call text into OpenAI `tool_calls`,
+and turns a client's tool schemas and tool results back into the model's prompt. Shared
+by every engine (closed and open kernels); the requirements here are about the
+`AutoModel` / `RestHandler` code, not the weights.
+
+Directory name gives the prefix: `TOOLS`.
+
+Background and evidence for the Gemma 4 requirements:
+`.claude/plans/gemma4-tool-calling.md` (local, gitignored) and
+[ROCm/FastFlowLM#722](https://github.com/ROCm/FastFlowLM/issues/722).
+
+## Gemma 4
+
+Gemma 4 emits `<|tool_call>call:NAME{ARGS}<tool_call|>` where `ARGS` is relaxed JSON:
+bare keys, strings wrapped in `<|"|>...<|"|>`. The shared parser lives in
+`src/include/AutoModel/gemma4_tool_parser.hpp` and serves the 12B and the E2B/E4B models.
+
+### TOOLS-GEMMA4-CONTINUATION: the whole tool result reaches the model
+**Applies to:** openflowlm-next (`src/common/AutoModel/modeling_gemma4_12b.cpp`)
+**Test category:** integration (needs the NPU and `gemma4-it:12b`)
+**Test:** `specs/tool-calling/tests/test_gemma4_continuation.py`
+
+With thinking off, the Gemma 4 template ends a fresh model turn with an empty thought
+block `<|channel>thought\n<channel|>`; the engine trims those four tokens from the prefill
+and feeds them back during decode so its checkpoint sits before them. After a tool
+response the template ends the prompt with `<tool_response|>` and adds nothing. The
+engine shall trim and re-feed only when the rendered prompt actually ends with the empty
+thought block, so a tool result is never shortened and no thought block is injected
+where the template did not write one.
+
+**Acceptance criteria:**
+- A request whose last message is a tool result, with thinking off, prefills exactly as
+  many tokens as the template renders (the server log's `Prefill chunk ... with N tokens`
+  equals the tokenizer's count of the rendered prompt).
+- A tool result `{"a_status": "open", "zz_code": "ZQX-7731"}` (the key sorts last, so the
+  value sits in the final tokens) asked back verbatim at temperature 0 returns
+  `ZQX-7731`, with thinking off and with thinking on.
+- A fresh user turn with thinking off still prefills four fewer tokens than rendered and
+  the generation still begins with the re-fed empty thought block (the existing
+  behaviour is kept where it applies).
+- In the continuation the model writes its own empty thought block (`<|channel>thought\n<channel|>`);
+  a thought block that holds only whitespace is not reported as `reasoning_content`, in
+  either response mode.
+
+### TOOLS-GEMMA4-ENVELOPE: a wrapped call resolves to the named tool
+**Applies to:** openflowlm-next (`src/include/AutoModel/gemma4_tool_parser.hpp`)
+**Test category:** unit
+**Test:** `src/test/gemma4_tool_parser/test.cpp`
+
+The model sometimes wraps the real call in a generic envelope whose outer name is
+`tool_call` (or `call`, `function`, `tool`, `function_call`) and whose arguments carry the
+real name under `id` or `name` and the real arguments under `args`, `arguments`,
+`parameters`, `params` or `input`. The parser shall return the inner name and inner
+arguments in that case, and leave every other call untouched.
+
+**Acceptance criteria:**
+- `call:tool_call{args:{query:"x"},id:<|"|>memory_search<|"|>}` parses to name
+  `memory_search`, arguments `{"query": "x"}` (the trace from FastFlowLM#722).
+- `call:function{name:<|"|>lookup_item_price<|"|>,arguments:{item:<|"|>widget<|"|>}}`
+  parses to `lookup_item_price` / `{"item": "widget"}`.
+- `call:tool_call{query:<|"|>x<|"|>}` (no inner name) stays `tool_call` / `{"query": "x"}`.
+- Direct calls, empty argument lists and nested object/array arguments parse as before.
+
+### TOOLS-GEMMA4-SCHEMA-TYPES: a type array in a tool schema does not fail the request
+**Applies to:** openflowlm-next (`src/include/AutoModel/gemma4_tool_parser.hpp`, both Gemma 4 `apply_chat_template`s)
+**Test category:** unit
+**Test:** `src/test/gemma4_tool_parser/test.cpp`
+
+The Gemma 4 template applies `| upper` to every parameter `type`; minja throws on a
+JSON-schema type array such as `["string", "null"]`, which fails the whole request. Before
+templating, the server shall fold every `type` array anywhere in a tool's parameter
+schema into its first non-null member, adding `nullable: true` when `null` was listed.
+
+**Acceptance criteria:**
+- `{"type": ["string", "null"]}` becomes `{"type": "string", "nullable": true}`; other keys
+  on that property are kept.
+- Arrays nested under `items`, `properties` and sub-objects are folded too.
+- A schema without type arrays is returned unchanged.
+- A request whose tools include such a field succeeds through `oflm serve` and the
+  model can call that tool (manual: `edge_cases.py` "nullable type array").

--- a/specs/tool-calling/tests/test_gemma4_continuation.py
+++ b/specs/tool-calling/tests/test_gemma4_continuation.py
@@ -1,0 +1,120 @@
+# Traces: TOOLS-GEMMA4-CONTINUATION (canonical spec: specs/tool-calling/spec.md)
+# Integration: needs `oflm serve gemma4-it:12b` (or flm serve) listening on localhost:52625
+# and the model's tokenizer + template on disk. Skips, with the reason, when either is absent.
+import json
+import os
+import urllib.error
+import urllib.request
+
+import pytest
+
+BASE = os.environ.get("OFLM_TEST_BASE_URL", "http://localhost:52625")
+MODEL = "gemma4-it:12b"
+MODEL_DIR_CANDIDATES = [
+    os.path.join(os.environ.get("OFLM_MODEL_PATH", ""), "models", "Gemma4-12B-IT-NPU2"),
+    os.path.join(os.environ.get("FLM_MODEL_PATH", ""), "models", "Gemma4-12B-IT-NPU2"),
+    os.path.expanduser("~/.oflm/models/Gemma4-12B-IT-NPU2"),
+    os.path.expanduser("~/.flm/models/Gemma4-12B-IT-NPU2"),
+]
+
+TOOL = {"type": "function", "function": {"name": "get_ticket", "description": "Fetch a support ticket by id.",
+        "parameters": {"type": "object", "properties": {"ticket_id": {"type": "string"}}, "required": ["ticket_id"]}}}
+RESULT = {"a_status": "open", "zz_code": "ZQX-7731"}  # zz_ sorts last, so the value sits in the final tokens
+
+
+def _server_up():
+    try:
+        urllib.request.urlopen(f"{BASE}/v1/models", timeout=3).read()
+        return True
+    except Exception:
+        return False
+
+
+def _model_dir():
+    for d in MODEL_DIR_CANDIDATES:
+        if os.path.isfile(os.path.join(d, "chat_template.jinja")) and os.path.isfile(os.path.join(d, "tokenizer.json")):
+            return d
+    return None
+
+
+pytestmark = pytest.mark.skipif(not _server_up(), reason=f"no server at {BASE}; start `oflm serve {MODEL}`")
+
+
+def _chat(messages, **extra):
+    body = dict(model=MODEL, messages=messages, tools=[TOOL], temperature=0.0, stream=False, **extra)
+    req = urllib.request.Request(f"{BASE}/v1/chat/completions", data=json.dumps(body).encode(),
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=600) as r:
+        d = json.loads(r.read().decode())
+    return d["choices"][0]["message"], d.get("usage", {})
+
+
+def _continuation_messages():
+    return [
+        {"role": "user", "content": "Fetch ticket 42 and reply with ONLY the exact value of its `zz_code` field, nothing else."},
+        {"role": "assistant", "content": None, "tool_calls": [
+            {"id": "c1", "type": "function", "function": {"name": "get_ticket", "arguments": json.dumps({"ticket_id": "42"})}}]},
+        {"role": "tool", "tool_call_id": "c1", "content": json.dumps(RESULT)},
+    ]
+
+
+def _rendered_token_count(messages_for_template, enable_thinking):
+    jinja2 = pytest.importorskip("jinja2")
+    tokenizers = pytest.importorskip("tokenizers")
+    d = _model_dir()
+    if d is None:
+        pytest.skip("Gemma4-12B-IT-NPU2 tokenizer/template not found on disk")
+    env = jinja2.Environment()
+    env.globals["raise_exception"] = lambda m: (_ for _ in ()).throw(Exception(m))
+    tpl = env.from_string(open(os.path.join(d, "chat_template.jinja"), encoding="utf-8").read())
+    out = tpl.render(messages=messages_for_template, tools=[TOOL], add_generation_prompt=True,
+                     bos_token="<bos>", enable_thinking=enable_thinking)
+    tok = tokenizers.Tokenizer.from_file(os.path.join(d, "tokenizer.json"))
+    return len(tok.encode(out, add_special_tokens=False).ids)
+
+
+@pytest.mark.parametrize("reasoning", ["none", "low"])
+def test_tail_of_tool_result_is_seen(reasoning):
+    msg, _ = _chat(_continuation_messages(), reasoning_effort=reasoning)
+    assert not msg.get("tool_calls"), msg
+    assert "ZQX-7731" in (msg.get("content") or ""), msg
+
+
+@pytest.mark.parametrize("stream", [False, True])
+def test_models_own_empty_thought_block_is_not_reported(stream):
+    body = dict(model=MODEL, messages=_continuation_messages(), tools=[TOOL], temperature=0.0,
+                stream=stream, reasoning_effort="none")
+    req = urllib.request.Request(f"{BASE}/v1/chat/completions", data=json.dumps(body).encode(),
+                                 headers={"Content-Type": "application/json"})
+    raw = urllib.request.urlopen(req, timeout=600).read().decode("utf-8")
+    reasoning = ""
+    if stream:
+        for line in raw.split("\n"):
+            if line.startswith("data: ") and line != "data: [DONE]":
+                delta = json.loads(line[6:])["choices"][0].get("delta", {})
+                reasoning += delta.get("reasoning_content") or ""
+    else:
+        reasoning = json.loads(raw)["choices"][0]["message"].get("reasoning_content") or ""
+    assert reasoning.strip() == "", repr(reasoning)
+
+
+def test_prefill_count_matches_render_after_tool_result():
+    # the server merges assistant tool_calls + tool messages into one assistant message
+    # with tool_responses before templating (rest_handler convert_tool_responses_gemma4)
+    merged = [
+        _continuation_messages()[0],
+        {"role": "assistant",
+         "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "get_ticket", "arguments": {"ticket_id": "42"}}}],
+         "tool_responses": [{"name": "get_ticket", "response": RESULT}]},
+    ]
+    expected = _rendered_token_count(merged, enable_thinking=False)
+    _, usage = _chat(_continuation_messages(), reasoning_effort="none")
+    assert usage.get("prompt_tokens") == expected, usage
+
+
+def test_fresh_turn_still_trims_the_empty_thought_block():
+    messages = [{"role": "user", "content": "Fetch ticket 42 using the tool."}]
+    expected = _rendered_token_count(messages, enable_thinking=False)
+    _, usage = _chat(messages, reasoning_effort="none")
+    # four tokens (<|channel> thought \n <channel|>) are trimmed from the prefill and fed back in decode
+    assert usage.get("prompt_tokens") == expected - 4, usage

--- a/specs/tool-calling/tests/test_request_params_reset.py
+++ b/specs/tool-calling/tests/test_request_params_reset.py
@@ -1,0 +1,50 @@
+# Traces: TOOLS-REQUEST-PARAMS-RESET (canonical spec: specs/tool-calling/spec.md)
+# Integration: needs `oflm serve gemma4-it:12b` listening on localhost:52625 (Gemma 4 is the
+# model whose default is no-think, which is what makes the leak observable). Skips with the
+# reason when no server answers.
+import json
+import os
+import urllib.request
+
+import pytest
+
+BASE = os.environ.get("OFLM_TEST_BASE_URL", "http://localhost:52625")
+MODEL = "gemma4-it:12b"
+
+
+def _server_up():
+    try:
+        urllib.request.urlopen(f"{BASE}/v1/models", timeout=3).read()
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _server_up(), reason=f"no server at {BASE}; start `oflm serve {MODEL}`")
+
+
+def _chat(**extra):
+    body = dict(model=MODEL, messages=[{"role": "user", "content": "In one short sentence, what is an NPU?"}],
+                stream=False, **extra)
+    req = urllib.request.Request(f"{BASE}/v1/chat/completions", data=json.dumps(body).encode(),
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=600) as r:
+        return json.loads(r.read().decode())["choices"][0]["message"]
+
+
+def test_reasoning_effort_does_not_leak_into_the_next_request():
+    with_thinking = _chat(reasoning_effort="low")
+    assert with_thinking.get("reasoning_content"), with_thinking
+    plain = _chat()
+    assert not plain.get("reasoning_content"), plain
+
+
+def test_temperature_does_not_leak_into_the_next_request():
+    # Gemma 4's load-time temperature is 1.0; at 0 two identical prompts repeat bit for bit,
+    # at the default they do not (same first sentence is fine, identical 60+ token text is not)
+    a = _chat(temperature=0.0, max_tokens=60)["content"]
+    b = _chat(temperature=0.0, max_tokens=60)["content"]
+    assert a == b, "temperature 0 should be deterministic"
+    c = _chat(max_tokens=60)["content"]
+    d = _chat(max_tokens=60)["content"]
+    assert not (c == d == a), "default temperature still pinned at 0 from the earlier request"

--- a/specs/tool-calling/tests/test_request_params_reset.py
+++ b/specs/tool-calling/tests/test_request_params_reset.py
@@ -2,6 +2,10 @@
 # Integration: needs `oflm serve gemma4-it:12b` listening on localhost:52625 (Gemma 4 is the
 # model whose default is no-think, which is what makes the leak observable). Skips with the
 # reason when no server answers.
+#
+# The reset lives in AutoModel, so every model with a thinking flag is covered by the same
+# two tests - point OFLM_TEST_MODEL at qwen3:8b or gpt-oss:20b (serving that model) to run
+# them there.
 import json
 import os
 import urllib.request
@@ -9,7 +13,7 @@ import urllib.request
 import pytest
 
 BASE = os.environ.get("OFLM_TEST_BASE_URL", "http://localhost:52625")
-MODEL = "gemma4-it:12b"
+MODEL = os.environ.get("OFLM_TEST_MODEL", "gemma4-it:12b")
 
 
 def _server_up():

--- a/src/common/AutoModel/automodel.cpp
+++ b/src/common/AutoModel/automodel.cpp
@@ -536,6 +536,29 @@ void AutoModel::set_sampler(sampler_config& sampler_config) {
     this->sampler = std::make_unique<Sampler>(this->lm_config->get("vocab_size"), sampler_config);
 }
 
+void AutoModel::snapshot_request_defaults() {
+    if (this->sampler == nullptr) return;
+    default_sampler_config_.temperature = this->sampler->temperature;
+    default_sampler_config_.top_k = this->sampler->top_k;
+    default_sampler_config_.top_p = this->sampler->top_p;
+    default_sampler_config_.min_p = this->sampler->min_p;
+    default_sampler_config_.rep_penalty = this->sampler->rep_penalty;
+    default_sampler_config_.freq_penalty = this->sampler->freq_penalty;
+    default_sampler_config_.pre_penalty = this->sampler->pre_penalty;
+    has_default_sampler_ = true;
+}
+
+void AutoModel::reset_request_defaults() {
+    if (this->sampler == nullptr || !has_default_sampler_) return;
+    this->sampler->temperature = default_sampler_config_.temperature;
+    this->sampler->top_k = default_sampler_config_.top_k;
+    this->sampler->top_p = default_sampler_config_.top_p;
+    this->sampler->min_p = default_sampler_config_.min_p;
+    this->sampler->rep_penalty = default_sampler_config_.rep_penalty;
+    this->sampler->freq_penalty = default_sampler_config_.freq_penalty;
+    this->sampler->pre_penalty = default_sampler_config_.pre_penalty;
+}
+
 /// \brief Set the max length
 /// \param MAX_L the max length
 /// \note The function will set the max length

--- a/src/common/AutoModel/automodel.cpp
+++ b/src/common/AutoModel/automodel.cpp
@@ -537,6 +537,9 @@ void AutoModel::set_sampler(sampler_config& sampler_config) {
 }
 
 void AutoModel::snapshot_request_defaults() {
+    default_enable_think_ = this->enable_think;
+    default_user_system_prompt_ = this->user_system_prompt;
+    default_extra_context_ = this->extra_context;
     if (this->sampler == nullptr) return;
     default_sampler_config_.temperature = this->sampler->temperature;
     default_sampler_config_.top_k = this->sampler->top_k;
@@ -549,6 +552,9 @@ void AutoModel::snapshot_request_defaults() {
 }
 
 void AutoModel::reset_request_defaults() {
+    this->enable_think = default_enable_think_;
+    this->user_system_prompt = default_user_system_prompt_;
+    this->extra_context = default_extra_context_;
     if (this->sampler == nullptr || !has_default_sampler_) return;
     this->sampler->temperature = default_sampler_config_.temperature;
     this->sampler->top_k = default_sampler_config_.top_k;

--- a/src/common/AutoModel/modeling_gemma4_12b.cpp
+++ b/src/common/AutoModel/modeling_gemma4_12b.cpp
@@ -6,399 +6,10 @@
 /// \note This is a source file for the Gemma4_12B class (text-only interface).
 
 #include "AutoModel/modeling_gemma4_12b.hpp"
+#include "AutoModel/gemma4_tool_parser.hpp"
 #include "metrices.hpp"
 #include "error_measure.hpp"
 #include <cassert>
-
-namespace {
-std::string trim_gemma4_12b_tool_value(std::string value) {
-    size_t start = value.find_first_not_of(" \t\r\n");
-    if (start == std::string::npos) {
-        return "";
-    }
-
-    size_t end = value.find_last_not_of(" \t\r\n");
-    return value.substr(start, end - start + 1);
-}
-
-// --- Gemma4 tool-args parser --------------------------------------------------
-// The model emits relaxed JSON for tool arguments:
-//   - keys are bare identifiers (e.g. `name:`) — sometimes also "..." quoted
-//   - string values are delimited by <|"|>...<|"|>, but the model frequently
-//     omits the opener and/or replaces the closer with a plain `"`
-//   - values can also be objects {..}, arrays [..], booleans, null, or numbers
-//   - inside a string value, raw `"`, raw newlines, and even the literal
-//     substring `<|"|>` can appear as content
-//
-// We rewrite the input into well-formed JSON via recursive-descent.
-struct Gemma4_12BArgsParser {
-    const std::string& s;
-    size_t i = 0;
-    static constexpr size_t marker_len = 5;
-    static constexpr const char* quote_marker_lit = "<|\"|>";
-
-    explicit Gemma4_12BArgsParser(const std::string& src) : s(src) {}
-
-    void skip_ws() {
-        while (i < s.size() &&
-               std::isspace(static_cast<unsigned char>(s[i]))) ++i;
-    }
-    void skip_ws_at(size_t& pos) const {
-        while (pos < s.size() &&
-               std::isspace(static_cast<unsigned char>(s[pos]))) ++pos;
-    }
-    bool match_marker(size_t pos) const {
-        return pos + marker_len <= s.size() &&
-               s.compare(pos, marker_len, quote_marker_lit) == 0;
-    }
-
-    static void json_escape_char(std::string& out, char c) {
-        switch (c) {
-            case '"':  out.append("\\\""); break;
-            case '\\': out.append("\\\\"); break;
-            case '\n': out.append("\\n");  break;
-            case '\r': out.append("\\r");  break;
-            case '\t': out.append("\\t");  break;
-            case '\b': out.append("\\b");  break;
-            case '\f': out.append("\\f");  break;
-            default:
-                if (static_cast<unsigned char>(c) < 0x20) {
-                    char buf[8];
-                    std::snprintf(buf, sizeof(buf), "\\u%04x",
-                                  static_cast<unsigned char>(c));
-                    out.append(buf);
-                } else {
-                    out.push_back(c);
-                }
-                break;
-        }
-    }
-
-    bool match_word(const char* w, size_t len) const {
-        if (i + len > s.size()) return false;
-        if (s.compare(i, len, w) != 0) return false;
-        if (i + len == s.size()) return true;
-        unsigned char nc = static_cast<unsigned char>(s[i + len]);
-        return !(std::isalnum(nc) || nc == '_');
-    }
-
-    // Parse one JSON value. `terminators` is the set of chars that end a
-    // bare (undelimited) string at depth 0 (e.g. ",}" inside an object,
-    // ",]" inside an array, "" at the very top).
-    std::string parse_value(const std::string& terminators) {
-        skip_ws();
-        if (i >= s.size()) return "null";
-        char c = s[i];
-        if (c == '{') return parse_object();
-        if (c == '[') return parse_array();
-        if (match_word("true",  4)) { i += 4; return "true";  }
-        if (match_word("false", 5)) { i += 5; return "false"; }
-        if (match_word("null",  4)) { i += 4; return "null";  }
-        if (c == '-' || (c >= '0' && c <= '9')) return parse_number();
-        return parse_string(terminators);
-    }
-
-    std::string parse_number() {
-        size_t start = i;
-        if (s[i] == '-') ++i;
-        while (i < s.size()) {
-            char c = s[i];
-            if ((c >= '0' && c <= '9') || c == '.' ||
-                c == 'e' || c == 'E' || c == '+' || c == '-') ++i;
-            else break;
-        }
-        return s.substr(start, i - start);
-    }
-
-    std::string parse_key() {
-        skip_ws();
-        std::string key;
-        if (i >= s.size()) return key;
-        if (match_marker(i)) {
-            i += marker_len;
-            while (i < s.size() && !match_marker(i)) key.push_back(s[i++]);
-            if (match_marker(i)) i += marker_len;
-        } else if (s[i] == '"') {
-            ++i;
-            while (i < s.size() && s[i] != '"') {
-                if (s[i] == '\\' && i + 1 < s.size()) {
-                    key.push_back(s[i]);
-                    key.push_back(s[i + 1]);
-                    i += 2;
-                } else {
-                    key.push_back(s[i++]);
-                }
-            }
-            if (i < s.size() && s[i] == '"') ++i;
-        } else {
-            while (i < s.size() &&
-                   (std::isalnum(static_cast<unsigned char>(s[i])) ||
-                    s[i] == '_')) {
-                key.push_back(s[i++]);
-            }
-        }
-        return key;
-    }
-
-    std::string parse_object() {
-        // assumes s[i] == '{'
-        ++i;
-        std::string out = "{";
-        bool first = true;
-        while (i < s.size()) {
-            skip_ws();
-            if (i >= s.size()) break;
-            if (s[i] == '}') { ++i; break; }
-
-            std::string key = parse_key();
-            if (key.empty()) {
-                // can't make progress; bail
-                if (i < s.size() && s[i] == '}') { ++i; }
-                break;
-            }
-            skip_ws();
-            if (i < s.size() && s[i] == ':') ++i;
-
-            std::string val = parse_value(",}");
-
-            if (!first) out.push_back(',');
-            first = false;
-            out.push_back('"');
-            for (char kc : key) json_escape_char(out, kc);
-            out.append("\":");
-            out.append(val);
-
-            skip_ws();
-            if (i < s.size() && s[i] == ',') ++i;
-        }
-        out.push_back('}');
-        return out;
-    }
-
-    std::string parse_array() {
-        // assumes s[i] == '['
-        ++i;
-        std::string out = "[";
-        bool first = true;
-        while (i < s.size()) {
-            skip_ws();
-            if (i >= s.size()) break;
-            if (s[i] == ']') { ++i; break; }
-
-            std::string val = parse_value(",]");
-            if (!first) out.push_back(',');
-            first = false;
-            out.append(val);
-
-            skip_ws();
-            if (i < s.size() && s[i] == ',') ++i;
-        }
-        out.push_back(']');
-        return out;
-    }
-
-    // Parse a string value. Accepts three forms:
-    //   - <|"|>...<|"|>  (or <|"|>...")  -- marker opener, marker or " closer
-    //   - "..."                          -- regular JSON string
-    //   - bare text                      -- ends at depth-0 terminator
-    std::string parse_string(const std::string& terminators) {
-        enum Mode { MARKER, QUOTE, BARE };
-        Mode mode = BARE;
-        if (match_marker(i)) { mode = MARKER; i += marker_len; }
-        else if (s[i] == '"') { mode = QUOTE; ++i; }
-
-        auto is_terminator = [&](size_t pos) {
-            size_t k = pos;
-            skip_ws_at(k);
-            if (k >= s.size()) return true;
-            return terminators.find(s[k]) != std::string::npos;
-        };
-
-        // QUOTE-mode only: honor JSON-style backslash escapes verbatim.
-        auto consume_quote_escape = [&](std::string& out) {
-            // s[i] == '\\'
-            if (i + 1 >= s.size()) {
-                json_escape_char(out, s[i]);
-                ++i;
-                return;
-            }
-            char nc = s[i + 1];
-            switch (nc) {
-                case '"': case '\\': case '/':
-                case 'b': case 'f': case 'n': case 'r': case 't':
-                    out.push_back('\\');
-                    out.push_back(nc);
-                    i += 2;
-                    return;
-                case 'u': {
-                    if (i + 5 < s.size() &&
-                        std::isxdigit(static_cast<unsigned char>(s[i + 2])) &&
-                        std::isxdigit(static_cast<unsigned char>(s[i + 3])) &&
-                        std::isxdigit(static_cast<unsigned char>(s[i + 4])) &&
-                        std::isxdigit(static_cast<unsigned char>(s[i + 5]))) {
-                        out.append(s, i, 6);
-                        i += 6;
-                        return;
-                    }
-                    break;
-                }
-                default: break;
-            }
-            json_escape_char(out, s[i]);
-            ++i;
-        };
-
-        // For MARKER and BARE modes we first collect the raw content, then
-        // JSON-encode it. Backslash policy is decided per-string:
-        //   - if every `\` is followed by a valid JSON escape char, treat
-        //     them as escapes (so e.g. `\n` becomes a real newline)
-        //   - otherwise treat every `\` as a literal char (so Windows paths
-        //     like `C:\Users\nock9\Desktop\abc.txt` are preserved verbatim)
-        auto is_escape_char = [](char c) {
-            return c == '"' || c == '\\' || c == '/' ||
-                   c == 'b' || c == 'f' || c == 'n' ||
-                   c == 'r' || c == 't' || c == 'u';
-        };
-        auto encode_raw = [&](const std::string& raw, std::string& out) {
-            bool all_valid = true;
-            for (size_t k = 0; k < raw.size(); ++k) {
-                if (raw[k] == '\\') {
-                    if (k + 1 >= raw.size() || !is_escape_char(raw[k + 1])) {
-                        all_valid = false;
-                        break;
-                    }
-                    ++k;
-                }
-            }
-            for (size_t k = 0; k < raw.size(); ++k) {
-                char c = raw[k];
-                if (c == '\\' && all_valid && k + 1 < raw.size()) {
-                    char nc = raw[k + 1];
-                    if (nc == 'u' && k + 5 < raw.size() &&
-                        std::isxdigit(static_cast<unsigned char>(raw[k + 2])) &&
-                        std::isxdigit(static_cast<unsigned char>(raw[k + 3])) &&
-                        std::isxdigit(static_cast<unsigned char>(raw[k + 4])) &&
-                        std::isxdigit(static_cast<unsigned char>(raw[k + 5]))) {
-                        out.append(raw, k, 6);
-                        k += 5;
-                    } else {
-                        out.push_back('\\');
-                        out.push_back(nc);
-                        ++k;
-                    }
-                } else {
-                    json_escape_char(out, c);
-                }
-            }
-        };
-
-        std::string value;
-        std::string raw;       // used in MARKER / BARE modes
-        int depth = 0;
-        while (i < s.size()) {
-            if (mode == MARKER) {
-                if (match_marker(i)) {
-                    size_t after = i + marker_len;
-                    if (is_terminator(after)) { i = after; break; }
-                    raw.append(quote_marker_lit, marker_len);
-                    i = after;
-                    continue;
-                }
-                if (s[i] == '"' || s[i] == '`') {
-                    // The model occasionally substitutes a plain `"` or even
-                    // a backtick `` ` `` for the closing <|"|> marker. Treat
-                    // either as a close only when followed by a terminator,
-                    // so they remain valid string content otherwise.
-                    if (is_terminator(i + 1)) { ++i; break; }
-                    raw.push_back(s[i]);
-                    ++i;
-                    continue;
-                }
-                raw.push_back(s[i]);
-                ++i;
-                continue;
-            }
-            if (mode == QUOTE) {
-                char c = s[i];
-                if (c == '\\') {
-                    consume_quote_escape(value);
-                    continue;
-                }
-                if (c == '"') { ++i; break; }
-                json_escape_char(value, c);
-                ++i;
-                continue;
-            }
-            // BARE
-            if (match_marker(i)) {
-                size_t after = i + marker_len;
-                if (depth == 0 && is_terminator(after)) { i = after; break; }
-                raw.append(quote_marker_lit, marker_len);
-                i = after;
-                continue;
-            }
-            char c = s[i];
-            if (depth == 0 && terminators.find(c) != std::string::npos) break;
-            if (c == '{' || c == '[' || c == '(') ++depth;
-            else if ((c == '}' || c == ']' || c == ')') && depth > 0) --depth;
-            raw.push_back(c);
-            ++i;
-        }
-
-        if (mode != QUOTE) {
-            encode_raw(raw, value);
-        }
-
-        std::string out = "\"";
-        out.append(value);
-        out.push_back('"');
-        return out;
-    }
-};
-
-std::pair<std::string, json> parse_gemma4_12b_tool_content(std::string tool_content) {
-    tool_content = trim_gemma4_12b_tool_value(tool_content);
-
-    const std::string prefix = "call:";
-    if (tool_content.find(prefix) == 0) {
-        tool_content = trim_gemma4_12b_tool_value(tool_content.substr(prefix.length()));
-    }
-
-    // only has tool name but no args
-    size_t brace_pos = tool_content.find('{');
-    if (brace_pos == std::string::npos) {
-        return {trim_gemma4_12b_tool_value(tool_content), json::object()};
-    }
-
-    std::string tool_name = trim_gemma4_12b_tool_value(tool_content.substr(0, brace_pos));
-    std::string args_str = trim_gemma4_12b_tool_value(tool_content.substr(brace_pos));
-
-    // Rewrite the relaxed args into well-formed JSON via recursive-descent.
-    Gemma4_12BArgsParser parser(args_str);
-    parser.skip_ws();
-    std::string normalized;
-    if (parser.i < args_str.size() && args_str[parser.i] == '{') {
-        normalized = parser.parse_object();
-    } else {
-        // Unexpected shape; wrap whatever we get into an object so the
-        // downstream JSON parse step still has a sensible structure.
-        normalized = parser.parse_value("");
-    }
-
-    // Final: parse to a real JSON object; fall back to empty object on failure.
-    json args_json = json::object();
-    try {
-        args_json = json::parse(normalized);
-    } catch (const std::exception& e) {
-        std::cerr << "[WARNING] Failed to parse tool args as JSON: "
-                  << e.what() << std::endl;
-        std::cerr << "Raw args: " << normalized << std::endl;
-    }
-
-    return {tool_name, args_json};
-}
-}
-
 
 /************              Gemma4_12B family            **************/
 Gemma4_12B::Gemma4_12B(oflm_rt::device* npu_device_inst) : AutoModel(npu_device_inst, "Gemma4_12B") {}
@@ -482,7 +93,7 @@ std::string Gemma4_12B::apply_chat_template(nlohmann::ordered_json& messages, nl
     inputs.extra_context = this->extra_context;
     inputs.extra_context["enable_thinking"] = this->enable_think;
     if (!tools.empty())
-        inputs.tools = tools;
+        inputs.tools = gemma4_tools::normalize_tools(tools);
     return this->chat_tmpl->apply(inputs, opt);
 }
 
@@ -867,8 +478,19 @@ bool Gemma4_12B::insert(chat_meta_info_t& meta_info, lm_uniform_input_t& input, 
         this->token_history = checkpoint_his; // restore the token history to be consistent with the restored KV cache, which is crucial for correct functioning of _shared_insert's prefix-matching logic
     }
 
-    size_t n = tokens.size();
-    tokens.resize(n - (this->enable_think ? 0 : 4));
+    // With thinking off the template ends a fresh model turn with an empty
+    // thought block. Those four tokens are trimmed here and fed back
+    // in generate(), so the checkpoint lands before them. After a tool response the
+    // template ends the prompt with <tool_response|> and nothing else - trimming
+    // there ate the tail of every tool result and injected a thought block the
+    // template never wrote.
+    static const std::string empty_thought = "<|channel>thought\n<channel|>";
+    this->feed_empty_thought = !this->enable_think &&
+        templated_text.size() >= empty_thought.size() &&
+        templated_text.compare(templated_text.size() - empty_thought.size(), empty_thought.size(), empty_thought) == 0;
+    if (this->feed_empty_thought) {
+        tokens.resize(tokens.size() - 4);
+    }
 
     gemma4_12b_multi_modal_payload_t multi_modal_payload;
     multi_modal_payload.image_payload = image_payload;
@@ -901,7 +523,7 @@ std::string Gemma4_12B::generate(chat_meta_info_t& meta_info, int length_limit, 
     std::string token_str;
     int sampled_token;
     int last_sampled_token;
-    if(!enable_think) {
+    if (this->feed_empty_thought) {
         this->token_history.push_back(boc_token_id);
         this->profiler_list[DECODING_TIME].start();
         this->lm_engine->forward(boc_token_id);
@@ -1047,6 +669,8 @@ NonStreamResult Gemma4_12B::parse_nstream_content(const std::string response_tex
     if (is_reasoning) {
         size_t start = think_start_pos + think_start_tag.length();
         result.reasoning_content = response_text.substr(start, think_end_pos - start);
+        // the model writes an empty thought block on its own in tool continuations; that is not reasoning
+        if (gemma4_tools::trim_value(result.reasoning_content).empty()) result.reasoning_content.clear();
     }
 
     // 2. Parse Tool Calling
@@ -1070,7 +694,7 @@ NonStreamResult Gemma4_12B::parse_nstream_content(const std::string response_tex
             }
 
             std::string tool_content = response_text.substr(block_content_start, block_end - block_content_start);
-            auto parsed_tool = parse_gemma4_12b_tool_content(tool_content);
+            auto parsed_tool = gemma4_tools::parse_tool_call(tool_content);
             result.tool_calls_list.emplace_back(parsed_tool.first, parsed_tool.second.dump());
         }
 
@@ -1146,7 +770,7 @@ StreamResult Gemma4_12B::parse_stream_content_impl(const std::string content, bo
 
                 static int tool_counter = 0;
                 result.tool_id = "call_" + std::to_string(std::time(nullptr)) + "_" + std::to_string(tool_counter++);
-                auto parsed_tool = parse_gemma4_12b_tool_content(tool_content);
+                auto parsed_tool = gemma4_tools::parse_tool_call(tool_content);
                 result.tool_name = parsed_tool.first;
                 result.tool_args_str = parsed_tool.second.dump();
                 return result;
@@ -1176,9 +800,14 @@ StreamResult Gemma4_12B::parse_stream_content_impl(const std::string content, bo
 
         // Flush the text content before the earliest marker
         if (min_pos != std::string::npos && min_pos > 0) {
-            result.content = buffer_.substr(0, min_pos);
-            result.type = current_mode_;
+            std::string ahead = buffer_.substr(0, min_pos);
             buffer_ = buffer_.substr(min_pos);
+            // a whitespace-only thought block is the model's own empty one, not reasoning
+            if (current_mode_ == StreamEventType::REASONING && gemma4_tools::trim_value(ahead).empty()) {
+                continue;
+            }
+            result.content = ahead;
+            result.type = current_mode_;
             return result;
         }
 
@@ -1226,6 +855,13 @@ StreamResult Gemma4_12B::parse_stream_content_impl(const std::string content, bo
             }
         }
 
+        // in a thought block, hold whitespace back until real text or the end marker arrives,
+        // so an empty block never reaches the client as a reasoning delta
+        if (safe_flush_len > 0 && current_mode_ == StreamEventType::REASONING &&
+            gemma4_tools::trim_value(buffer_.substr(0, safe_flush_len)).empty()) {
+            result.type = StreamEventType::WAITING;
+            return result;
+        }
         if (safe_flush_len > 0) {
             result.content = buffer_.substr(0, safe_flush_len);
             result.type = current_mode_;

--- a/src/common/AutoModel/modeling_gemma4e.cpp
+++ b/src/common/AutoModel/modeling_gemma4e.cpp
@@ -7,407 +7,8 @@
 
 
 #include "AutoModel/modeling_gemma4e.hpp"
+#include "AutoModel/gemma4_tool_parser.hpp"
 #include "metrices.hpp"
-
-namespace {
-std::string trim_gemma4e_tool_value(std::string value) {
-    size_t start = value.find_first_not_of(" \t\r\n");
-    if (start == std::string::npos) {
-        return "";
-    }
-
-    size_t end = value.find_last_not_of(" \t\r\n");
-    return value.substr(start, end - start + 1);
-}
-
-// --- Gemma4e tool-args parser -------------------------------------------------
-// The model emits relaxed JSON for tool arguments:
-//   - keys are bare identifiers (e.g. `name:`) — sometimes also "..." quoted
-//   - string values are delimited by <|"|>...<|"|>, but the model frequently
-//     omits the opener and/or replaces the closer with a plain `"`
-//   - values can also be objects {..}, arrays [..], booleans, null, or numbers
-//   - inside a string value, raw `"`, raw newlines, and even the literal
-//     substring `<|"|>` can appear as content
-//
-// We rewrite the input into well-formed JSON via recursive-descent.
-struct Gemma4eArgsParser {
-    const std::string& s;
-    size_t i = 0;
-    static constexpr size_t marker_len = 5;
-    static constexpr const char* quote_marker_lit = "<|\"|>";
-
-    explicit Gemma4eArgsParser(const std::string& src) : s(src) {}
-
-    void skip_ws() {
-        while (i < s.size() &&
-               std::isspace(static_cast<unsigned char>(s[i]))) ++i;
-    }
-    void skip_ws_at(size_t& pos) const {
-        while (pos < s.size() &&
-               std::isspace(static_cast<unsigned char>(s[pos]))) ++pos;
-    }
-    bool match_marker(size_t pos) const {
-        return pos + marker_len <= s.size() &&
-               s.compare(pos, marker_len, quote_marker_lit) == 0;
-    }
-
-    static void json_escape_char(std::string& out, char c) {
-        switch (c) {
-            case '"':  out.append("\\\""); break;
-            case '\\': out.append("\\\\"); break;
-            case '\n': out.append("\\n");  break;
-            case '\r': out.append("\\r");  break;
-            case '\t': out.append("\\t");  break;
-            case '\b': out.append("\\b");  break;
-            case '\f': out.append("\\f");  break;
-            default:
-                if (static_cast<unsigned char>(c) < 0x20) {
-                    char buf[8];
-                    std::snprintf(buf, sizeof(buf), "\\u%04x",
-                                  static_cast<unsigned char>(c));
-                    out.append(buf);
-                } else {
-                    out.push_back(c);
-                }
-                break;
-        }
-    }
-
-    bool match_word(const char* w, size_t len) const {
-        if (i + len > s.size()) return false;
-        if (s.compare(i, len, w) != 0) return false;
-        if (i + len == s.size()) return true;
-        unsigned char nc = static_cast<unsigned char>(s[i + len]);
-        return !(std::isalnum(nc) || nc == '_');
-    }
-
-    // Parse one JSON value. `terminators` is the set of chars that end a
-    // bare (undelimited) string at depth 0 (e.g. ",}" inside an object,
-    // ",]" inside an array, "" at the very top).
-    std::string parse_value(const std::string& terminators) {
-        skip_ws();
-        if (i >= s.size()) return "null";
-        char c = s[i];
-        if (c == '{') return parse_object();
-        if (c == '[') return parse_array();
-        if (match_word("true",  4)) { i += 4; return "true";  }
-        if (match_word("false", 5)) { i += 5; return "false"; }
-        if (match_word("null",  4)) { i += 4; return "null";  }
-        if (c == '-' || (c >= '0' && c <= '9')) return parse_number();
-        return parse_string(terminators);
-    }
-
-    std::string parse_number() {
-        size_t start = i;
-        if (s[i] == '-') ++i;
-        while (i < s.size()) {
-            char c = s[i];
-            if ((c >= '0' && c <= '9') || c == '.' ||
-                c == 'e' || c == 'E' || c == '+' || c == '-') ++i;
-            else break;
-        }
-        return s.substr(start, i - start);
-    }
-
-    std::string parse_key() {
-        skip_ws();
-        std::string key;
-        if (i >= s.size()) return key;
-        if (match_marker(i)) {
-            i += marker_len;
-            while (i < s.size() && !match_marker(i)) key.push_back(s[i++]);
-            if (match_marker(i)) i += marker_len;
-        } else if (s[i] == '"') {
-            ++i;
-            while (i < s.size() && s[i] != '"') {
-                if (s[i] == '\\' && i + 1 < s.size()) {
-                    key.push_back(s[i]);
-                    key.push_back(s[i + 1]);
-                    i += 2;
-                } else {
-                    key.push_back(s[i++]);
-                }
-            }
-            if (i < s.size() && s[i] == '"') ++i;
-        } else {
-            while (i < s.size() &&
-                   (std::isalnum(static_cast<unsigned char>(s[i])) ||
-                    s[i] == '_')) {
-                key.push_back(s[i++]);
-            }
-        }
-        return key;
-    }
-
-    std::string parse_object() {
-        // assumes s[i] == '{'
-        ++i;
-        std::string out = "{";
-        bool first = true;
-        while (i < s.size()) {
-            skip_ws();
-            if (i >= s.size()) break;
-            if (s[i] == '}') { ++i; break; }
-
-            std::string key = parse_key();
-            if (key.empty()) {
-                // can't make progress; bail
-                if (i < s.size() && s[i] == '}') { ++i; }
-                break;
-            }
-            skip_ws();
-            if (i < s.size() && s[i] == ':') ++i;
-
-            std::string val = parse_value(",}");
-
-            if (!first) out.push_back(',');
-            first = false;
-            out.push_back('"');
-            for (char kc : key) json_escape_char(out, kc);
-            out.append("\":");
-            out.append(val);
-
-            skip_ws();
-            if (i < s.size() && s[i] == ',') ++i;
-        }
-        out.push_back('}');
-        return out;
-    }
-
-    std::string parse_array() {
-        // assumes s[i] == '['
-        ++i;
-        std::string out = "[";
-        bool first = true;
-        while (i < s.size()) {
-            skip_ws();
-            if (i >= s.size()) break;
-            if (s[i] == ']') { ++i; break; }
-
-            std::string val = parse_value(",]");
-            if (!first) out.push_back(',');
-            first = false;
-            out.append(val);
-
-            skip_ws();
-            if (i < s.size() && s[i] == ',') ++i;
-        }
-        out.push_back(']');
-        return out;
-    }
-
-    // Parse a string value. Accepts three forms:
-    //   - <|"|>...<|"|>  (or <|"|>...")  -- marker opener, marker or " closer
-    //   - "..."                          -- regular JSON string
-    //   - bare text                      -- ends at depth-0 terminator
-    std::string parse_string(const std::string& terminators) {
-        enum Mode { MARKER, QUOTE, BARE };
-        Mode mode = BARE;
-        if (match_marker(i)) { mode = MARKER; i += marker_len; }
-        else if (s[i] == '"') { mode = QUOTE; ++i; }
-
-        auto is_terminator = [&](size_t pos) {
-            size_t k = pos;
-            skip_ws_at(k);
-            if (k >= s.size()) return true;
-            return terminators.find(s[k]) != std::string::npos;
-        };
-
-        // QUOTE-mode only: honor JSON-style backslash escapes verbatim.
-        auto consume_quote_escape = [&](std::string& out) {
-            // s[i] == '\\'
-            if (i + 1 >= s.size()) {
-                json_escape_char(out, s[i]);
-                ++i;
-                return;
-            }
-            char nc = s[i + 1];
-            switch (nc) {
-                case '"': case '\\': case '/':
-                case 'b': case 'f': case 'n': case 'r': case 't':
-                    out.push_back('\\');
-                    out.push_back(nc);
-                    i += 2;
-                    return;
-                case 'u': {
-                    if (i + 5 < s.size() &&
-                        std::isxdigit(static_cast<unsigned char>(s[i + 2])) &&
-                        std::isxdigit(static_cast<unsigned char>(s[i + 3])) &&
-                        std::isxdigit(static_cast<unsigned char>(s[i + 4])) &&
-                        std::isxdigit(static_cast<unsigned char>(s[i + 5]))) {
-                        out.append(s, i, 6);
-                        i += 6;
-                        return;
-                    }
-                    break;
-                }
-                default: break;
-            }
-            json_escape_char(out, s[i]);
-            ++i;
-        };
-
-        // For MARKER and BARE modes we first collect the raw content, then
-        // JSON-encode it. Backslash policy is decided per-string:
-        //   - if every `\` is followed by a valid JSON escape char, treat
-        //     them as escapes (so e.g. `\n` becomes a real newline)
-        //   - otherwise treat every `\` as a literal char (so Windows paths
-        //     like `C:\Users\nock9\Desktop\abc.txt` are preserved verbatim)
-        auto is_escape_char = [](char c) {
-            return c == '"' || c == '\\' || c == '/' ||
-                   c == 'b' || c == 'f' || c == 'n' ||
-                   c == 'r' || c == 't' || c == 'u';
-        };
-        auto encode_raw = [&](const std::string& raw, std::string& out) {
-            bool all_valid = true;
-            for (size_t k = 0; k < raw.size(); ++k) {
-                if (raw[k] == '\\') {
-                    if (k + 1 >= raw.size() || !is_escape_char(raw[k + 1])) {
-                        all_valid = false;
-                        break;
-                    }
-                    ++k;
-                }
-            }
-            for (size_t k = 0; k < raw.size(); ++k) {
-                char c = raw[k];
-                if (c == '\\' && all_valid && k + 1 < raw.size()) {
-                    char nc = raw[k + 1];
-                    if (nc == 'u' && k + 5 < raw.size() &&
-                        std::isxdigit(static_cast<unsigned char>(raw[k + 2])) &&
-                        std::isxdigit(static_cast<unsigned char>(raw[k + 3])) &&
-                        std::isxdigit(static_cast<unsigned char>(raw[k + 4])) &&
-                        std::isxdigit(static_cast<unsigned char>(raw[k + 5]))) {
-                        out.append(raw, k, 6);
-                        k += 5;
-                    } else {
-                        out.push_back('\\');
-                        out.push_back(nc);
-                        ++k;
-                    }
-                } else {
-                    json_escape_char(out, c);
-                }
-            }
-        };
-
-        std::string value;
-        std::string raw;       // used in MARKER / BARE modes
-        int depth = 0;
-        while (i < s.size()) {
-            if (mode == MARKER) {
-                if (match_marker(i)) {
-                    size_t after = i + marker_len;
-                    if (is_terminator(after)) { i = after; break; }
-                    raw.append(quote_marker_lit, marker_len);
-                    i = after;
-                    continue;
-                }
-                if (s[i] == '"' || s[i] == '`') {
-                    // The model occasionally substitutes a plain `"` or even
-                    // a backtick `` ` `` for the closing <|"|> marker. Treat
-                    // either as a close only when followed by a terminator,
-                    // so they remain valid string content otherwise.
-                    if (is_terminator(i + 1)) { ++i; break; }
-                    raw.push_back(s[i]);
-                    ++i;
-                    continue;
-                }
-                raw.push_back(s[i]);
-                ++i;
-                continue;
-            }
-            if (mode == QUOTE) {
-                char c = s[i];
-                if (c == '\\') {
-                    consume_quote_escape(value);
-                    continue;
-                }
-                if (c == '"') { ++i; break; }
-                json_escape_char(value, c);
-                ++i;
-                continue;
-            }
-            // BARE
-            if (match_marker(i)) {
-                size_t after = i + marker_len;
-                if (depth == 0 && is_terminator(after)) { i = after; break; }
-                raw.append(quote_marker_lit, marker_len);
-                i = after;
-                continue;
-            }
-            char c = s[i];
-            if (depth == 0 && terminators.find(c) != std::string::npos) break;
-            if (c == '{' || c == '[' || c == '(') ++depth;
-            else if ((c == '}' || c == ']' || c == ')') && depth > 0) --depth;
-            raw.push_back(c);
-            ++i;
-        }
-
-        if (mode != QUOTE) {
-            encode_raw(raw, value);
-        }
-
-        std::string out = "\"";
-        out.append(value);
-        out.push_back('"');
-        return out;
-    }
-};
-
-std::pair<std::string, json> parse_gemma4e_tool_content(std::string tool_content) {
-    tool_content = trim_gemma4e_tool_value(tool_content);
-
-    const std::string prefix = "call:";
-    if (tool_content.find(prefix) == 0) {
-        tool_content = trim_gemma4e_tool_value(tool_content.substr(prefix.length()));
-    }
-
-    // std::cout << "[DEBUG after prefix removal]" << std::endl;
-    // std::cout << tool_content << std::endl;
-
-    // only has tool name but no args
-    size_t brace_pos = tool_content.find('{');
-    if (brace_pos == std::string::npos) {
-        return {trim_gemma4e_tool_value(tool_content), json::object()};
-    }
-
-    std::string tool_name = trim_gemma4e_tool_value(tool_content.substr(0, brace_pos));
-    std::string args_str = trim_gemma4e_tool_value(tool_content.substr(brace_pos));
-
-    // std::cout << "[DEBUG after parsing tool name and args]" << std::endl;
-    // std::cout << "Tool Name: " << tool_name << std::endl;
-    // std::cout << "Args Str: " << args_str << std::endl;
-
-    // Rewrite the relaxed args into well-formed JSON via recursive-descent.
-    Gemma4eArgsParser parser(args_str);
-    parser.skip_ws();
-    std::string normalized;
-    if (parser.i < args_str.size() && args_str[parser.i] == '{') {
-        normalized = parser.parse_object();
-    } else {
-        // Unexpected shape; wrap whatever we get into an object so the
-        // downstream JSON parse step still has a sensible structure.
-        normalized = parser.parse_value("");
-    }
-
-    // std::cout << "[DEBUG normalized args]" << std::endl;
-    // std::cout << normalized << std::endl;
-
-    // Final: parse to a real JSON object; fall back to empty object on failure.
-    json args_json = json::object();
-    try {
-        args_json = json::parse(normalized);
-    } catch (const std::exception& e) {
-        std::cerr << "[WARNING] Failed to parse tool args as JSON: "
-                  << e.what() << std::endl;
-        std::cerr << "Raw args: " << normalized << std::endl;
-    }
-
-    return {tool_name, args_json};
-}
-}
-
 
 /************              Gemma4e family            **************/
 Gemma4e::Gemma4e(oflm_rt::device* npu_device_inst) : AutoModel(npu_device_inst, "Gemma4e") {}
@@ -454,7 +55,7 @@ std::string Gemma4e::apply_chat_template(nlohmann::ordered_json& messages, nlohm
     inputs.extra_context = this->extra_context;
     inputs.extra_context["enable_thinking"] = this->enable_think;
     if (!tools.empty())
-        inputs.tools = tools;
+        inputs.tools = gemma4_tools::normalize_tools(tools);
     return this->chat_tmpl->apply(inputs);
 }
 
@@ -966,6 +567,8 @@ NonStreamResult Gemma4e::parse_nstream_content(const std::string response_text) 
     if (is_reasoning) {
         size_t start = think_start_pos + think_start_tag.length();
         result.reasoning_content = response_text.substr(start, think_end_pos - start);
+        // the model writes an empty thought block on its own in tool continuations; that is not reasoning
+        if (gemma4_tools::trim_value(result.reasoning_content).empty()) result.reasoning_content.clear();
     }
 
     // 2. Parse Tool Calling
@@ -989,7 +592,7 @@ NonStreamResult Gemma4e::parse_nstream_content(const std::string response_text) 
             }
 
             std::string tool_content = response_text.substr(block_content_start, block_end - block_content_start);
-            auto parsed_tool = parse_gemma4e_tool_content(tool_content);
+            auto parsed_tool = gemma4_tools::parse_tool_call(tool_content);
             result.tool_calls_list.emplace_back(parsed_tool.first, parsed_tool.second.dump());
         }
 
@@ -1067,7 +670,7 @@ StreamResult Gemma4e::parse_stream_content_impl(const std::string content, bool 
                 result.type = StreamEventType::TOOL_DONE;
                 
                 result.tool_id = "call_" + std::to_string(std::time(nullptr));
-                auto parsed_tool = parse_gemma4e_tool_content(tool_content);
+                auto parsed_tool = gemma4_tools::parse_tool_call(tool_content);
                 result.tool_name = parsed_tool.first;
                 result.tool_args_str = parsed_tool.second.dump();
                 return result;
@@ -1097,9 +700,14 @@ StreamResult Gemma4e::parse_stream_content_impl(const std::string content, bool 
 
         // Flush the text content before the earliest marker
         if (min_pos != std::string::npos && min_pos > 0) {
-            result.content = buffer_.substr(0, min_pos);
-            result.type = current_mode_;
+            std::string ahead = buffer_.substr(0, min_pos);
             buffer_ = buffer_.substr(min_pos);
+            // a whitespace-only thought block is the model's own empty one, not reasoning
+            if (current_mode_ == StreamEventType::REASONING && gemma4_tools::trim_value(ahead).empty()) {
+                continue;
+            }
+            result.content = ahead;
+            result.type = current_mode_;
             return result;
         }
 
@@ -1147,12 +755,19 @@ StreamResult Gemma4e::parse_stream_content_impl(const std::string content, bool 
             }
         }
 
+        // in a thought block, hold whitespace back until real text or the end marker arrives,
+        // so an empty block never reaches the client as a reasoning delta
+        if (safe_flush_len > 0 && current_mode_ == StreamEventType::REASONING &&
+            gemma4_tools::trim_value(buffer_.substr(0, safe_flush_len)).empty()) {
+            result.type = StreamEventType::WAITING;
+            return result;
+        }
         if (safe_flush_len > 0) {
             result.content = buffer_.substr(0, safe_flush_len);
             result.type = current_mode_;
             buffer_ = buffer_.substr(safe_flush_len);
             return result;
-        } 
+        }
         else if (buffer_.length() > 0) {
             result.type = StreamEventType::WAITING;
             return result;

--- a/src/common/AutoModel/modeling_gpt_oss.cpp
+++ b/src/common/AutoModel/modeling_gpt_oss.cpp
@@ -7,7 +7,10 @@
 #include "AutoModel/modeling_gpt_oss.hpp"   
 
 
-GPT_OSS::GPT_OSS(oflm_rt::device* npu_device_inst) : AutoModel(npu_device_inst, "gpt-oss") {}
+// harmony always reasons, so unlike the base default this one starts on
+GPT_OSS::GPT_OSS(oflm_rt::device* npu_device_inst) : AutoModel(npu_device_inst, "gpt-oss") {
+    this->enable_think = true;
+}
 
 void GPT_OSS::load_model(std::string model_path, json model_info, int default_context_length, bool enable_preemption) {
     this->model_path = model_path;

--- a/src/include/AutoModel/automodel.hpp
+++ b/src/include/AutoModel/automodel.hpp
@@ -151,6 +151,14 @@ protected:
 
     nlohmann::json extra_context;
 
+	/// Lives here rather than in each model so one reset covers them all - a request
+	/// that turns thinking on used to leave it on for whatever came next.
+	bool enable_think = false;
+
+	bool default_enable_think_ = false;
+	std::string default_user_system_prompt_;
+	nlohmann::json default_extra_context_;
+
 	typedef enum {
 		PREFILL_TIME,
 		DECODING_TIME,
@@ -226,10 +234,12 @@ public:
 	/// \param sampler_config the sampler config
 	virtual void set_sampler(sampler_config& sampler_config);
 
-	/// Per-request settings (temperature, top_k, thinking, ...) are applied to the engine
-	/// only when a request carries them, so without these two they leak from one request
-	/// into the next. The server snapshots once after load and resets at the top of each
-	/// chat request. The base handles the sampler; models with a thinking flag override both.
+	/// Per-request settings (temperature, top_k, thinking, system prompt, ...) are applied
+	/// to the engine only when a request carries them, so without these two they leak from
+	/// one request into the next. The server snapshots once after load and resets at the
+	/// top of each chat request. The base covers everything it owns - the sampler,
+	/// enable_think, the system prompt and extra_context - so a model only overrides these
+	/// if it keeps request state of its own outside those.
 	virtual void snapshot_request_defaults();
 	virtual void reset_request_defaults();
 

--- a/src/include/AutoModel/automodel.hpp
+++ b/src/include/AutoModel/automodel.hpp
@@ -144,6 +144,8 @@ protected:
     bool has_bos_token;
     int bos_token_id;
     std::vector<int> eos_token_ids;
+    sampler_config default_sampler_config_;
+    bool has_default_sampler_ = false;
 
 	std::string user_system_prompt = "";
 
@@ -223,6 +225,13 @@ public:
 	/// \brief Set the sampler
 	/// \param sampler_config the sampler config
 	virtual void set_sampler(sampler_config& sampler_config);
+
+	/// Per-request settings (temperature, top_k, thinking, ...) are applied to the engine
+	/// only when a request carries them, so without these two they leak from one request
+	/// into the next. The server snapshots once after load and resets at the top of each
+	/// chat request. The base handles the sampler; models with a thinking flag override both.
+	virtual void snapshot_request_defaults();
+	virtual void reset_request_defaults();
 
 	/// \brief Set the max length
 	/// \param MAX_L the max length

--- a/src/include/AutoModel/gemma4_tool_parser.hpp
+++ b/src/include/AutoModel/gemma4_tool_parser.hpp
@@ -1,0 +1,473 @@
+/// ile gemma4_tool_parser.hpp
+/// rief Gemma 4 tool-call text -> (name, JSON args), shared by the 12B and E2B/E4B models.
+///
+/// The model emits `<|tool_call>call:NAME{ARGS}<tool_call|>` where ARGS is relaxed JSON:
+/// bare keys, strings wrapped in <|"|>...<|"|>, and enough variation on that to need a
+/// real parser. One copy here; the two model files used to carry identical duplicates.
+
+#pragma once
+#include <nlohmann/json.hpp>
+#include <cctype>
+#include <cstdio>
+#include <iostream>
+#include <string>
+#include <utility>
+
+namespace gemma4_tools {
+using json = nlohmann::ordered_json;
+
+inline std::string trim_value(std::string value) {
+    size_t start = value.find_first_not_of(" \t\r\n");
+    if (start == std::string::npos) {
+        return "";
+    }
+
+    size_t end = value.find_last_not_of(" \t\r\n");
+    return value.substr(start, end - start + 1);
+}
+
+// The model emits relaxed JSON for tool arguments:
+//   - keys are bare identifiers (e.g. `name:`) — sometimes also "..." quoted
+//   - string values are delimited by <|"|>...<|"|>, but the model frequently
+//     omits the opener and/or replaces the closer with a plain `"`
+//   - values can also be objects {..}, arrays [..], booleans, null, or numbers
+//   - inside a string value, raw `"`, raw newlines, and even the literal
+//     substring `<|"|>` can appear as content
+//
+// We rewrite the input into well-formed JSON via recursive-descent.
+struct ArgsParser {
+    const std::string& s;
+    size_t i = 0;
+    static constexpr size_t marker_len = 5;
+    static constexpr const char* quote_marker_lit = "<|\"|>";
+
+    explicit ArgsParser(const std::string& src) : s(src) {}
+
+    void skip_ws() {
+        while (i < s.size() &&
+               std::isspace(static_cast<unsigned char>(s[i]))) ++i;
+    }
+    void skip_ws_at(size_t& pos) const {
+        while (pos < s.size() &&
+               std::isspace(static_cast<unsigned char>(s[pos]))) ++pos;
+    }
+    bool match_marker(size_t pos) const {
+        return pos + marker_len <= s.size() &&
+               s.compare(pos, marker_len, quote_marker_lit) == 0;
+    }
+
+    static void json_escape_char(std::string& out, char c) {
+        switch (c) {
+            case '"':  out.append("\\\""); break;
+            case '\\': out.append("\\\\"); break;
+            case '\n': out.append("\\n");  break;
+            case '\r': out.append("\\r");  break;
+            case '\t': out.append("\\t");  break;
+            case '\b': out.append("\\b");  break;
+            case '\f': out.append("\\f");  break;
+            default:
+                if (static_cast<unsigned char>(c) < 0x20) {
+                    char buf[8];
+                    std::snprintf(buf, sizeof(buf), "\\u%04x",
+                                  static_cast<unsigned char>(c));
+                    out.append(buf);
+                } else {
+                    out.push_back(c);
+                }
+                break;
+        }
+    }
+
+    bool match_word(const char* w, size_t len) const {
+        if (i + len > s.size()) return false;
+        if (s.compare(i, len, w) != 0) return false;
+        if (i + len == s.size()) return true;
+        unsigned char nc = static_cast<unsigned char>(s[i + len]);
+        return !(std::isalnum(nc) || nc == '_');
+    }
+
+    // Parse one JSON value. `terminators` is the set of chars that end a
+    // bare (undelimited) string at depth 0 (e.g. ",}" inside an object,
+    // ",]" inside an array, "" at the very top).
+    std::string parse_value(const std::string& terminators) {
+        skip_ws();
+        if (i >= s.size()) return "null";
+        char c = s[i];
+        if (c == '{') return parse_object();
+        if (c == '[') return parse_array();
+        if (match_word("true",  4)) { i += 4; return "true";  }
+        if (match_word("false", 5)) { i += 5; return "false"; }
+        if (match_word("null",  4)) { i += 4; return "null";  }
+        if (c == '-' || (c >= '0' && c <= '9')) return parse_number();
+        return parse_string(terminators);
+    }
+
+    std::string parse_number() {
+        size_t start = i;
+        if (s[i] == '-') ++i;
+        while (i < s.size()) {
+            char c = s[i];
+            if ((c >= '0' && c <= '9') || c == '.' ||
+                c == 'e' || c == 'E' || c == '+' || c == '-') ++i;
+            else break;
+        }
+        return s.substr(start, i - start);
+    }
+
+    std::string parse_key() {
+        skip_ws();
+        std::string key;
+        if (i >= s.size()) return key;
+        if (match_marker(i)) {
+            i += marker_len;
+            while (i < s.size() && !match_marker(i)) key.push_back(s[i++]);
+            if (match_marker(i)) i += marker_len;
+        } else if (s[i] == '"') {
+            ++i;
+            while (i < s.size() && s[i] != '"') {
+                if (s[i] == '\\' && i + 1 < s.size()) {
+                    key.push_back(s[i]);
+                    key.push_back(s[i + 1]);
+                    i += 2;
+                } else {
+                    key.push_back(s[i++]);
+                }
+            }
+            if (i < s.size() && s[i] == '"') ++i;
+        } else {
+            while (i < s.size() &&
+                   (std::isalnum(static_cast<unsigned char>(s[i])) ||
+                    s[i] == '_')) {
+                key.push_back(s[i++]);
+            }
+        }
+        return key;
+    }
+
+    std::string parse_object() {
+        // assumes s[i] == '{'
+        ++i;
+        std::string out = "{";
+        bool first = true;
+        while (i < s.size()) {
+            skip_ws();
+            if (i >= s.size()) break;
+            if (s[i] == '}') { ++i; break; }
+
+            std::string key = parse_key();
+            if (key.empty()) {
+                // can't make progress; bail
+                if (i < s.size() && s[i] == '}') { ++i; }
+                break;
+            }
+            skip_ws();
+            if (i < s.size() && s[i] == ':') ++i;
+
+            std::string val = parse_value(",}");
+
+            if (!first) out.push_back(',');
+            first = false;
+            out.push_back('"');
+            for (char kc : key) json_escape_char(out, kc);
+            out.append("\":");
+            out.append(val);
+
+            skip_ws();
+            if (i < s.size() && s[i] == ',') ++i;
+        }
+        out.push_back('}');
+        return out;
+    }
+
+    std::string parse_array() {
+        // assumes s[i] == '['
+        ++i;
+        std::string out = "[";
+        bool first = true;
+        while (i < s.size()) {
+            skip_ws();
+            if (i >= s.size()) break;
+            if (s[i] == ']') { ++i; break; }
+
+            std::string val = parse_value(",]");
+            if (!first) out.push_back(',');
+            first = false;
+            out.append(val);
+
+            skip_ws();
+            if (i < s.size() && s[i] == ',') ++i;
+        }
+        out.push_back(']');
+        return out;
+    }
+
+    // Parse a string value. Accepts three forms:
+    //   - <|"|>...<|"|>  (or <|"|>...")  -- marker opener, marker or " closer
+    //   - "..."                          -- regular JSON string
+    //   - bare text                      -- ends at depth-0 terminator
+    std::string parse_string(const std::string& terminators) {
+        enum Mode { MARKER, QUOTE, BARE };
+        Mode mode = BARE;
+        if (match_marker(i)) { mode = MARKER; i += marker_len; }
+        else if (s[i] == '"') { mode = QUOTE; ++i; }
+
+        auto is_terminator = [&](size_t pos) {
+            size_t k = pos;
+            skip_ws_at(k);
+            if (k >= s.size()) return true;
+            return terminators.find(s[k]) != std::string::npos;
+        };
+
+        // QUOTE-mode only: honor JSON-style backslash escapes verbatim.
+        auto consume_quote_escape = [&](std::string& out) {
+            // s[i] == '\\'
+            if (i + 1 >= s.size()) {
+                json_escape_char(out, s[i]);
+                ++i;
+                return;
+            }
+            char nc = s[i + 1];
+            switch (nc) {
+                case '"': case '\\': case '/':
+                case 'b': case 'f': case 'n': case 'r': case 't':
+                    out.push_back('\\');
+                    out.push_back(nc);
+                    i += 2;
+                    return;
+                case 'u': {
+                    if (i + 5 < s.size() &&
+                        std::isxdigit(static_cast<unsigned char>(s[i + 2])) &&
+                        std::isxdigit(static_cast<unsigned char>(s[i + 3])) &&
+                        std::isxdigit(static_cast<unsigned char>(s[i + 4])) &&
+                        std::isxdigit(static_cast<unsigned char>(s[i + 5]))) {
+                        out.append(s, i, 6);
+                        i += 6;
+                        return;
+                    }
+                    break;
+                }
+                default: break;
+            }
+            json_escape_char(out, s[i]);
+            ++i;
+        };
+
+        // For MARKER and BARE modes we first collect the raw content, then
+        // JSON-encode it. Backslash policy is decided per-string:
+        //   - if every `\` is followed by a valid JSON escape char, treat
+        //     them as escapes (so e.g. `\n` becomes a real newline)
+        //   - otherwise treat every `\` as a literal char (so Windows paths
+        //     like `C:\Users\nock9\Desktop\abc.txt` are preserved verbatim)
+        auto is_escape_char = [](char c) {
+            return c == '"' || c == '\\' || c == '/' ||
+                   c == 'b' || c == 'f' || c == 'n' ||
+                   c == 'r' || c == 't' || c == 'u';
+        };
+        auto encode_raw = [&](const std::string& raw, std::string& out) {
+            bool all_valid = true;
+            for (size_t k = 0; k < raw.size(); ++k) {
+                if (raw[k] == '\\') {
+                    if (k + 1 >= raw.size() || !is_escape_char(raw[k + 1])) {
+                        all_valid = false;
+                        break;
+                    }
+                    ++k;
+                }
+            }
+            for (size_t k = 0; k < raw.size(); ++k) {
+                char c = raw[k];
+                if (c == '\\' && all_valid && k + 1 < raw.size()) {
+                    char nc = raw[k + 1];
+                    if (nc == 'u' && k + 5 < raw.size() &&
+                        std::isxdigit(static_cast<unsigned char>(raw[k + 2])) &&
+                        std::isxdigit(static_cast<unsigned char>(raw[k + 3])) &&
+                        std::isxdigit(static_cast<unsigned char>(raw[k + 4])) &&
+                        std::isxdigit(static_cast<unsigned char>(raw[k + 5]))) {
+                        out.append(raw, k, 6);
+                        k += 5;
+                    } else {
+                        out.push_back('\\');
+                        out.push_back(nc);
+                        ++k;
+                    }
+                } else {
+                    json_escape_char(out, c);
+                }
+            }
+        };
+
+        std::string value;
+        std::string raw;       // used in MARKER / BARE modes
+        int depth = 0;
+        while (i < s.size()) {
+            if (mode == MARKER) {
+                if (match_marker(i)) {
+                    size_t after = i + marker_len;
+                    if (is_terminator(after)) { i = after; break; }
+                    raw.append(quote_marker_lit, marker_len);
+                    i = after;
+                    continue;
+                }
+                if (s[i] == '"' || s[i] == '`') {
+                    // The model occasionally substitutes a plain `"` or even
+                    // a backtick `` ` `` for the closing <|"|> marker. Treat
+                    // either as a close only when followed by a terminator,
+                    // so they remain valid string content otherwise.
+                    if (is_terminator(i + 1)) { ++i; break; }
+                    raw.push_back(s[i]);
+                    ++i;
+                    continue;
+                }
+                raw.push_back(s[i]);
+                ++i;
+                continue;
+            }
+            if (mode == QUOTE) {
+                char c = s[i];
+                if (c == '\\') {
+                    consume_quote_escape(value);
+                    continue;
+                }
+                if (c == '"') { ++i; break; }
+                json_escape_char(value, c);
+                ++i;
+                continue;
+            }
+            // BARE
+            if (match_marker(i)) {
+                size_t after = i + marker_len;
+                if (depth == 0 && is_terminator(after)) { i = after; break; }
+                raw.append(quote_marker_lit, marker_len);
+                i = after;
+                continue;
+            }
+            char c = s[i];
+            if (depth == 0 && terminators.find(c) != std::string::npos) break;
+            if (c == '{' || c == '[' || c == '(') ++depth;
+            else if ((c == '}' || c == ']' || c == ')') && depth > 0) --depth;
+            raw.push_back(c);
+            ++i;
+        }
+
+        if (mode != QUOTE) {
+            encode_raw(raw, value);
+        }
+
+        std::string out = "\"";
+        out.append(value);
+        out.push_back('"');
+        return out;
+    }
+};
+
+inline std::pair<std::string, json> parse_tool_content(std::string tool_content) {
+    tool_content = trim_value(tool_content);
+
+    const std::string prefix = "call:";
+    if (tool_content.find(prefix) == 0) {
+        tool_content = trim_value(tool_content.substr(prefix.length()));
+    }
+
+    // only has tool name but no args
+    size_t brace_pos = tool_content.find('{');
+    if (brace_pos == std::string::npos) {
+        return {trim_value(tool_content), json::object()};
+    }
+
+    std::string tool_name = trim_value(tool_content.substr(0, brace_pos));
+    std::string args_str = trim_value(tool_content.substr(brace_pos));
+
+    // Rewrite the relaxed args into well-formed JSON via recursive-descent.
+    ArgsParser parser(args_str);
+    parser.skip_ws();
+    std::string normalized;
+    if (parser.i < args_str.size() && args_str[parser.i] == '{') {
+        normalized = parser.parse_object();
+    } else {
+        // Unexpected shape; wrap whatever we get into an object so the
+        // downstream JSON parse step still has a sensible structure.
+        normalized = parser.parse_value("");
+    }
+
+    // Final: parse to a real JSON object; fall back to empty object on failure.
+    json args_json = json::object();
+    try {
+        args_json = json::parse(normalized);
+    } catch (const std::exception& e) {
+        std::cerr << "[WARNING] Failed to parse tool args as JSON: "
+                  << e.what() << std::endl;
+        std::cerr << "Raw args: " << normalized << std::endl;
+    }
+
+    return {tool_name, args_json};
+}
+
+/// The model sometimes wraps the real call in a generic envelope, e.g.
+/// `call:tool_call{args:{query:...},id:<|"|>memory_search<|"|>}` (ROCm/FastFlowLM#722).
+/// Recover the named tool so the client sees a call it can execute.
+inline void unwrap_envelope(std::string& name, json& args) {
+    static const char* wrappers[] = {"tool_call", "call", "function", "tool", "function_call"};
+    bool wrapped = false;
+    for (const char* w : wrappers) if (name == w) wrapped = true;
+    if (!wrapped || !args.is_object()) return;
+
+    std::string inner_name;
+    for (const char* k : {"name", "id", "function", "tool"}) {
+        if (args.contains(k) && args[k].is_string()) { inner_name = args[k].get<std::string>(); break; }
+    }
+    if (inner_name.empty()) return;
+
+    json inner_args = json::object();
+    for (const char* k : {"args", "arguments", "parameters", "params", "input"}) {
+        if (args.contains(k) && args[k].is_object()) { inner_args = args[k]; break; }
+    }
+    name = inner_name;
+    args = inner_args;
+}
+
+/// Parse one tool-call body (everything between <|tool_call> and <tool_call|>) into the
+/// tool name and its arguments as a JSON object. Unparseable args come back as {}.
+inline std::pair<std::string, json> parse_tool_call(std::string tool_content) {
+    auto parsed = parse_tool_content(std::move(tool_content));
+    unwrap_envelope(parsed.first, parsed.second);
+    return parsed;
+}
+
+/// The chat template applies `| upper` to every parameter `type`, and minja throws when
+/// that is a JSON-schema type array such as ["string", "null"] (Python's Jinja would
+/// stringify it). Fold such arrays into the first non-null type plus `nullable: true`,
+/// which the template already understands, so one optional field cannot fail the
+/// whole request. Recurses through nested schemas.
+template <typename J>
+inline void normalize_schema_types(J& node) {
+    if (node.is_array()) {
+        for (auto& item : node) normalize_schema_types(item);
+        return;
+    }
+    if (!node.is_object()) return;
+    auto type_it = node.find("type");
+    if (type_it != node.end() && type_it->is_array()) {
+        std::string first;
+        bool nullable = false;
+        for (const auto& t : *type_it) {
+            if (!t.is_string()) continue;
+            const std::string s = t.template get<std::string>();
+            if (s == "null") nullable = true;
+            else if (first.empty()) first = s;
+        }
+        if (first.empty()) first = nullable ? "string" : "object";
+        *type_it = first;
+        if (nullable) node["nullable"] = true;
+    }
+    for (auto& kv : node.items()) {
+        if (kv.key() == "type") continue;
+        normalize_schema_types(kv.value());
+    }
+}
+
+template <typename J>
+inline J normalize_tools(J tools) {
+    normalize_schema_types(tools);
+    return tools;
+}
+}  // namespace gemma4_tools

--- a/src/include/AutoModel/gemma4_tool_parser.hpp
+++ b/src/include/AutoModel/gemma4_tool_parser.hpp
@@ -1,5 +1,5 @@
-/// ile gemma4_tool_parser.hpp
-/// rief Gemma 4 tool-call text -> (name, JSON args), shared by the 12B and E2B/E4B models.
+/// \file gemma4_tool_parser.hpp
+/// \brief Gemma 4 tool-call text -> (name, JSON args), shared by the 12B and E2B/E4B models.
 ///
 /// The model emits `<|tool_call>call:NAME{ARGS}<tool_call|>` where ARGS is relaxed JSON:
 /// bare keys, strings wrapped in <|"|>...<|"|>, and enough variation on that to need a
@@ -406,19 +406,32 @@ inline std::pair<std::string, json> parse_tool_content(std::string tool_content)
 /// `call:tool_call{args:{query:...},id:<|"|>memory_search<|"|>}` (ROCm/FastFlowLM#722).
 /// Recover the named tool so the client sees a call it can execute.
 inline void unwrap_envelope(std::string& name, json& args) {
+    static const char* name_keys[] = {"name", "id", "function", "tool"};
+    static const char* args_keys[] = {"args", "arguments", "parameters", "params", "input"};
     static const char* wrappers[] = {"tool_call", "call", "function", "tool", "function_call"};
+
     bool wrapped = false;
     for (const char* w : wrappers) if (name == w) wrapped = true;
     if (!wrapped || !args.is_object()) return;
 
+    // A tool really named `function` or `tool` is legal, so the name alone is not enough -
+    // every key has to be one an envelope would carry. Without this, a call like
+    // `function{name:<|"|>x<|"|>,quantity:2}` would be read as an envelope and quantity dropped.
+    for (auto& kv : args.items()) {
+        bool known = false;
+        for (const char* k : name_keys) if (kv.key() == k) known = true;
+        for (const char* k : args_keys) if (kv.key() == k) known = true;
+        if (!known) return;
+    }
+
     std::string inner_name;
-    for (const char* k : {"name", "id", "function", "tool"}) {
+    for (const char* k : name_keys) {
         if (args.contains(k) && args[k].is_string()) { inner_name = args[k].get<std::string>(); break; }
     }
     if (inner_name.empty()) return;
 
     json inner_args = json::object();
-    for (const char* k : {"args", "arguments", "parameters", "params", "input"}) {
+    for (const char* k : args_keys) {
         if (args.contains(k) && args[k].is_object()) { inner_args = args[k]; break; }
     }
     name = inner_name;

--- a/src/include/AutoModel/modeling_gemma4_12b.hpp
+++ b/src/include/AutoModel/modeling_gemma4_12b.hpp
@@ -25,6 +25,7 @@
 class Gemma4_12B : public AutoModel {
 private:
     bool enable_think = false;
+    bool default_enable_think = false;
     // set per insert(): the prompt ended with the empty thought block that was trimmed off
     bool feed_empty_thought = false;
 
@@ -117,6 +118,15 @@ public:
     /// \param parameter_name the name of the parameter
     /// \param value the value to set (can be any type)
     /// \return true if the parameter was configured successfully, false otherwise
+    void snapshot_request_defaults() override {
+        AutoModel::snapshot_request_defaults();
+        default_enable_think = enable_think;
+    }
+    void reset_request_defaults() override {
+        AutoModel::reset_request_defaults();
+        enable_think = default_enable_think;
+    }
+
     bool configure_parameter(std::string parameter_name, const std::any& value) override {
         if (parameter_name == "enable_think") {
             try {

--- a/src/include/AutoModel/modeling_gemma4_12b.hpp
+++ b/src/include/AutoModel/modeling_gemma4_12b.hpp
@@ -25,6 +25,8 @@
 class Gemma4_12B : public AutoModel {
 private:
     bool enable_think = false;
+    // set per insert(): the prompt ended with the empty thought block that was trimmed off
+    bool feed_empty_thought = false;
 
     void setup_tokenizer(std::string model_path);
 

--- a/src/include/AutoModel/modeling_gemma4_12b.hpp
+++ b/src/include/AutoModel/modeling_gemma4_12b.hpp
@@ -24,8 +24,6 @@
 /************              Gemma4_12B (text only)            **************/
 class Gemma4_12B : public AutoModel {
 private:
-    bool enable_think = false;
-    bool default_enable_think = false;
     // set per insert(): the prompt ended with the empty thought block that was trimmed off
     bool feed_empty_thought = false;
 
@@ -118,15 +116,6 @@ public:
     /// \param parameter_name the name of the parameter
     /// \param value the value to set (can be any type)
     /// \return true if the parameter was configured successfully, false otherwise
-    void snapshot_request_defaults() override {
-        AutoModel::snapshot_request_defaults();
-        default_enable_think = enable_think;
-    }
-    void reset_request_defaults() override {
-        AutoModel::reset_request_defaults();
-        enable_think = default_enable_think;
-    }
-
     bool configure_parameter(std::string parameter_name, const std::any& value) override {
         if (parameter_name == "enable_think") {
             try {

--- a/src/include/AutoModel/modeling_gemma4e.hpp
+++ b/src/include/AutoModel/modeling_gemma4e.hpp
@@ -36,8 +36,6 @@ private:
     static constexpr int think_start_id = 100;
     static constexpr int think_end_id = 101;
 
-    bool enable_think = false;
-    bool default_enable_think = false;
     bool enable_tool = false;
     void setup_tokenizer(std::string model_path);
     
@@ -99,15 +97,6 @@ public:
 	/// \param parameter_name the name of the parameter
 	/// \param value the value to set (can be any type)
 	/// \return true if the parameter was configured successfully, false otherwise
-    void snapshot_request_defaults() override {
-        AutoModel::snapshot_request_defaults();
-        default_enable_think = enable_think;
-    }
-    void reset_request_defaults() override {
-        AutoModel::reset_request_defaults();
-        enable_think = default_enable_think;
-    }
-
 	bool configure_parameter(std::string parameter_name, const std::any& value) override{
         if (parameter_name == "enable_think") {
             try {

--- a/src/include/AutoModel/modeling_gemma4e.hpp
+++ b/src/include/AutoModel/modeling_gemma4e.hpp
@@ -37,6 +37,7 @@ private:
     static constexpr int think_end_id = 101;
 
     bool enable_think = false;
+    bool default_enable_think = false;
     bool enable_tool = false;
     void setup_tokenizer(std::string model_path);
     
@@ -98,6 +99,15 @@ public:
 	/// \param parameter_name the name of the parameter
 	/// \param value the value to set (can be any type)
 	/// \return true if the parameter was configured successfully, false otherwise
+    void snapshot_request_defaults() override {
+        AutoModel::snapshot_request_defaults();
+        default_enable_think = enable_think;
+    }
+    void reset_request_defaults() override {
+        AutoModel::reset_request_defaults();
+        enable_think = default_enable_think;
+    }
+
 	bool configure_parameter(std::string parameter_name, const std::any& value) override{
         if (parameter_name == "enable_think") {
             try {

--- a/src/include/AutoModel/modeling_gpt_oss.hpp
+++ b/src/include/AutoModel/modeling_gpt_oss.hpp
@@ -11,9 +11,8 @@
 class GPT_OSS : public AutoModel {
 private:
 
-    bool enable_think = true;
-
     std::string reasoning_effort = "low";
+    std::string default_reasoning_effort = "low";
     std::string model_identity = "You are ChatGPT, a large language model trained by OpenAI.";
     std::string role = "developer";
 
@@ -49,6 +48,17 @@ public:
     StreamResult parse_stream_content(const std::string content);
     chat_template_type_t get_chat_template_type() {
         return chat_template_type_t::harmony;
+    }
+
+    // apply_chat_template reads reasoning_effort directly, so the base reset of
+    // extra_context is not enough to keep one request's effort out of the next
+    void snapshot_request_defaults() override {
+        AutoModel::snapshot_request_defaults();
+        default_reasoning_effort = reasoning_effort;
+    }
+    void reset_request_defaults() override {
+        AutoModel::reset_request_defaults();
+        reasoning_effort = default_reasoning_effort;
     }
 
     /// \brief Override configure_parameter to handle GPT-oss-specific parameters

--- a/src/include/AutoModel/modeling_qwen3.hpp
+++ b/src/include/AutoModel/modeling_qwen3.hpp
@@ -13,7 +13,6 @@
 class Qwen3 : public AutoModel {
 private:
 
-    bool enable_think = false;
     bool enable_tool = false;
     
     int think_start_id = 151667;

--- a/src/include/AutoModel/modeling_qwen3_5vl.hpp
+++ b/src/include/AutoModel/modeling_qwen3_5vl.hpp
@@ -24,7 +24,6 @@
 class Qwen3_5VL : public AutoModel {
 private:
 
-    bool enable_think = false;
     bool enable_tool = false;
     int think_start_id = 248068;
     int think_end_id = 248069;

--- a/src/include/AutoModel/modeling_qwen3_6_moe.hpp
+++ b/src/include/AutoModel/modeling_qwen3_6_moe.hpp
@@ -24,7 +24,6 @@
 class Qwen3_6_MOE : public AutoModel {
 private:
 
-    bool enable_think = false;
     bool enable_tool = false;
     int think_start_id = 248068;
     int think_end_id = 248069;

--- a/src/inno/oflm.iss
+++ b/src/inno/oflm.iss
@@ -269,7 +269,7 @@ begin
     Exit;
   end;
   Result := '52625';
-  end;
+end;
 
 procedure InitializeWizard;
 begin

--- a/src/open_qwen36/README.md
+++ b/src/open_qwen36/README.md
@@ -557,9 +557,9 @@ on a memory-starved box, not the kernels.
   (`vision/vit.cpp`, checked against transformers with the shipped weights to
   4e-6) and its rows enter the model as embedding vectors at their M-RoPE
   positions (`Core::step_embed`). The app's Qwen3.6 and Qwen3.5 model classes no
-  longer need the closed engine for images. `flm-test --vision` on the open
+  longer need the closed engine for images. `oflm-test --vision` on the open
   engine is the acceptance (OPEN-VISION-EMBED).
-- **The weight file** is still FLM's `.q4nx`. The GGUF path is a separate piece
+- **The weight file** is still OFLM's `.q4nx`. The GGUF path is a separate piece
   of work; this reader is ~150 lines and will go with it. The chunk format is read
   per tensor, so a container mixing q8 and q4_1 -- which is what the 35B fine-tunes
   ship, q8 attention and shared experts over q4_1 routed experts -- loads and packs;

--- a/src/open_qwen36/core.hpp
+++ b/src/open_qwen36/core.hpp
@@ -122,23 +122,6 @@ public:
     /// when asked.
     void step_gemm_block(const std::vector<int>& ids, size_t t_real, bool want_logits);
 
-    /// 0167/#32: the GEMM-route batched-prefill block size (manifest.hpp's
-    /// GemmBlockProgram), or 0 when the loaded kernel set has none / its
-    /// layer types disagree -- refuses rather than guesses.
-    size_t gemm_block_t() const { return gemm_block_t_; }
-    /// T tokens through every layer as 5 GEMM dispatches (q|k|v fused,
-    /// o_proj, gate_proj, up_proj, down_proj) plus T single-token attnpos-
-    /// patched attention dispatches between GEMM A' and GEMM O, with
-    /// HOST-side fp64 RMSNorm/residual/SwiGLU between every GEMM stage (see
-    /// manifest.hpp's GemmBlockProgram docstring for the full chain).
-    /// `ids.size()` must equal gemm_block_t(); the caller pads a short tail
-    /// with any in-range token id (hardware-proven exact: the real columns'
-    /// output does not depend on what the padding columns carry) and passes
-    /// the REAL count as `t_real` so position only advances by the real
-    /// tokens. Logits, like step(), only for the (t_real-1)th token, only
-    /// when asked.
-    void step_gemm_block(const std::vector<int>& ids, size_t t_real, bool want_logits);
-
     int position() const { return pos_; }
     /// Test hook: place the next token at `pos` without decoding up to it.
     void seek(int pos);

--- a/src/open_qwen36/core.hpp
+++ b/src/open_qwen36/core.hpp
@@ -122,6 +122,23 @@ public:
     /// when asked.
     void step_gemm_block(const std::vector<int>& ids, size_t t_real, bool want_logits);
 
+    /// 0167/#32: the GEMM-route batched-prefill block size (manifest.hpp's
+    /// GemmBlockProgram), or 0 when the loaded kernel set has none / its
+    /// layer types disagree -- refuses rather than guesses.
+    size_t gemm_block_t() const { return gemm_block_t_; }
+    /// T tokens through every layer as 5 GEMM dispatches (q|k|v fused,
+    /// o_proj, gate_proj, up_proj, down_proj) plus T single-token attnpos-
+    /// patched attention dispatches between GEMM A' and GEMM O, with
+    /// HOST-side fp64 RMSNorm/residual/SwiGLU between every GEMM stage (see
+    /// manifest.hpp's GemmBlockProgram docstring for the full chain).
+    /// `ids.size()` must equal gemm_block_t(); the caller pads a short tail
+    /// with any in-range token id (hardware-proven exact: the real columns'
+    /// output does not depend on what the padding columns carry) and passes
+    /// the REAL count as `t_real` so position only advances by the real
+    /// tokens. Logits, like step(), only for the (t_real-1)th token, only
+    /// when asked.
+    void step_gemm_block(const std::vector<int>& ids, size_t t_real, bool want_logits);
+
     int position() const { return pos_; }
     /// Test hook: place the next token at `pos` without decoding up to it.
     void seek(int pos);

--- a/src/server/rest_handler.cpp
+++ b/src/server/rest_handler.cpp
@@ -460,21 +460,6 @@ RestHandler::ModelLoad RestHandler::ensure_model_loaded(const std::string& model
             this->current_model_tag = "model-faker";
             return ModelLoad::NotChatModel;
         }
-        switch (downloader.is_model_downloaded(ensure_tag)) {
-            case ModelDownloader::ModelStatus::Ready:
-                break;
-            case ModelDownloader::ModelStatus::Outdated:
-            case ModelDownloader::ModelStatus::Missing:
-                downloader.pull_model(ensure_tag, this->modelscope);
-                break;
-            case ModelDownloader::ModelStatus::Incompatible:
-                // auto_chat_engine holds a freshly CONSTRUCTED engine that was never
-                // loaded, and current_model_tag still names the model just evicted --
-                // so the next request for that tag took the fast path straight into it.
-                // Leave the same state the load-failure catch below leaves.
-                this->auto_chat_engine.reset();
-                this->current_model_tag = "model-faker";
-                return ModelLoad::LoadFailed;
             }
         auto [new_ensure_tag, model_info] = supported_models.get_model_info(ensure_tag);
         auto_chat_engine->configure_parameter("img_pre_resize", this->img_pre_resize);
@@ -992,107 +977,6 @@ void RestHandler::handle_embeddings(const json& request,
         // It refuses now, and names what IS loaded. An unknown model is an
         // error every OpenAI client already understands.
 #ifndef FASTFLOWLM_LINUX_LIMITED_MODELS
-        if (this->auto_embedding_engine) {
-            const std::string loaded = this->auto_embedding_engine->get_current_model();
-            if (!model.empty() && !loaded.empty() && model != loaded) {
-                json err = { {"error", {
-                    {"message", "this server has '" + loaded + "' loaded, not '" +
-                                model + "'. One embedding model is loaded per "
-                                "server; start another with --embeddingmodel " +
-                                model + " to serve it."},
-                    {"type", "invalid_request_error"},
-                    {"param", "model"},
-                    {"code", "model_not_found"}
-                }} };
-                send_response(err);
-                return;
-            }
-        }
-#endif
-
-        // The task prompt. nomic-embed-text and friends prepend a per-task prefix, and
-        // which one is chosen changes the vector materially -- measured on this server,
-        // search_query against search_document on the same text is cosine 0.914, not 1.
-        // This handler used to pass task_query unconditionally and ignore the request, so
-        // every DOCUMENT was embedded as a QUERY and no caller could tell: the vector is
-        // correctly shaped, correctly normed and deterministic either way.
-        // The task prompt. nomic-embed-text and friends prepend a per-task prefix, and
-        // which one is chosen changes the vector materially -- measured on this server,
-        // search_query against search_document on the same text is cosine 0.914, not 1.
-        // This handler used to pass task_query unconditionally and ignore the request, so
-        // every DOCUMENT was embedded as a QUERY and no caller could tell.
-        embedding_task_type_t task_type = embedding_task_type_t::task_query;
-        const std::string accepted = openai_compat::task_names_csv();
-        std::vector<std::string> declared;
-        bool supports_prompts = false;
-#ifndef FASTFLOWLM_LINUX_LIMITED_MODELS
-        if (this->auto_embedding_engine) {
-            declared = this->auto_embedding_engine->prompt_names();
-            supports_prompts = this->auto_embedding_engine->supports_task_prompts();
-        }
-#endif
-        const openai_compat::TaskResolution tr = openai_compat::resolve_task(request);
-        using TRS = openai_compat::TaskResolution::Status;
-
-        const openai_compat::TaskPolicy policy =
-            openai_compat::task_policy(supports_prompts, !declared.empty(), tr.status != TRS::Absent);
-        if (policy == openai_compat::TaskPolicy::NotSupported) {
-            // prompt_for() returns an empty prefix for a model with no prompt table,
-            // so this used to answer 200 with an UNPREFIXED vector -- correctly
-            // shaped, correctly normed, and not what was asked for.
-            // src/open_npue_adapter/README.md: "model has no prompts, a prompt is
-            // given | error".
-            send_response(json{{"error", {
-                {"message", "model '" + model + "' has no task prompts; remove '" + tr.field +
-                            "'. Passing one would be ignored, and the vector would come back "
-                            "correctly shaped and unprefixed with nothing to show it."},
-                {"type", "invalid_request_error"}, {"param", tr.field}, {"code", "invalid_value"}}}});
-            return;
-        }
-        if (policy == openai_compat::TaskPolicy::Required) {
-            std::string names;
-            for (const auto& n : declared) names += (names.empty() ? "" : ", ") + n;
-            // Quote the REST vocabulary, not `declared`: the validator only accepts
-            // the former, so naming the latter sent clients to values it refuses.
-            json err = { {"error", {
-                {"message", "this model requires a task prompt: pass 'prompt_name' as "
-                            "one of [" + accepted + "] (this model declares the prompts [" +
-                            names + "], which those names map onto). Refusing to pick one -- "
-                            "the prefix changes the vector (search_query against "
-                            "search_document on the same text is cosine 0.914 here), and the "
-                            "result is correctly shaped, correctly normed and deterministic "
-                            "either way, so nothing downstream can tell the wrong one was used."},
-                {"type", "invalid_request_error"},
-                {"param", "prompt_name"},
-                {"code", "missing_required_parameter"}
-            }} };
-            send_response(err);
-            return;
-        }
-        if (tr.status == TRS::NotAString) {
-            send_response(json{{"error", {
-                {"message", "'" + tr.field + "' must be a string, one of [" + accepted + "]"},
-                {"type", "invalid_request_error"}, {"param", tr.field}, {"code", "invalid_value"}}}});
-            return;
-        }
-        if (tr.status == TRS::Unknown) {
-            send_response(json{{"error", {
-                {"message", "unknown " + tr.field + " '" + tr.value + "'. Known: [" + accepted +
-                            "]. Refusing to substitute one: an embedding under the wrong task "
-                            "prompt is correctly shaped and correctly normed, so nothing "
-                            "downstream can tell it is wrong."},
-                {"type", "invalid_request_error"}, {"param", tr.field}, {"code", "invalid_value"}}}});
-            return;
-        }
-        if (tr.status == TRS::Conflict) {
-            send_response(json{{"error", {
-                {"message", "'prompt_name' and 'task_type' are aliases and disagree "
-                            "('task_type' says '" + tr.value + "'). Send one, or send the same "
-                            "task in both."},
-                {"type", "invalid_request_error"}, {"param", tr.field}, {"code", "invalid_value"}}}});
-            return;
-        }
-        if (tr.status == TRS::Ok) task_type = tr.task;
 
         std::vector<std::string> inputs;
 

--- a/src/server/rest_handler.cpp
+++ b/src/server/rest_handler.cpp
@@ -460,7 +460,6 @@ RestHandler::ModelLoad RestHandler::ensure_model_loaded(const std::string& model
             this->current_model_tag = "model-faker";
             return ModelLoad::NotChatModel;
         }
-            }
         auto [new_ensure_tag, model_info] = supported_models.get_model_info(ensure_tag);
         auto_chat_engine->configure_parameter("img_pre_resize", this->img_pre_resize);
         try {
@@ -980,6 +979,107 @@ void RestHandler::handle_embeddings(const json& request,
         // It refuses now, and names what IS loaded. An unknown model is an
         // error every OpenAI client already understands.
 #ifndef FASTFLOWLM_LINUX_LIMITED_MODELS
+        if (this->auto_embedding_engine) {
+            const std::string loaded = this->auto_embedding_engine->get_current_model();
+            if (!model.empty() && !loaded.empty() && model != loaded) {
+                json err = { {"error", {
+                    {"message", "this server has '" + loaded + "' loaded, not '" +
+                                model + "'. One embedding model is loaded per "
+                                "server; start another with --embeddingmodel " +
+                                model + " to serve it."},
+                    {"type", "invalid_request_error"},
+                    {"param", "model"},
+                    {"code", "model_not_found"}
+                }} };
+                send_response(err);
+                return;
+            }
+        }
+#endif
+
+        // The task prompt. nomic-embed-text and friends prepend a per-task prefix, and
+        // which one is chosen changes the vector materially -- measured on this server,
+        // search_query against search_document on the same text is cosine 0.914, not 1.
+        // This handler used to pass task_query unconditionally and ignore the request, so
+        // every DOCUMENT was embedded as a QUERY and no caller could tell: the vector is
+        // correctly shaped, correctly normed and deterministic either way.
+        // The task prompt. nomic-embed-text and friends prepend a per-task prefix, and
+        // which one is chosen changes the vector materially -- measured on this server,
+        // search_query against search_document on the same text is cosine 0.914, not 1.
+        // This handler used to pass task_query unconditionally and ignore the request, so
+        // every DOCUMENT was embedded as a QUERY and no caller could tell.
+        embedding_task_type_t task_type = embedding_task_type_t::task_query;
+        const std::string accepted = openai_compat::task_names_csv();
+        std::vector<std::string> declared;
+        bool supports_prompts = false;
+#ifndef FASTFLOWLM_LINUX_LIMITED_MODELS
+        if (this->auto_embedding_engine) {
+            declared = this->auto_embedding_engine->prompt_names();
+            supports_prompts = this->auto_embedding_engine->supports_task_prompts();
+        }
+#endif
+        const openai_compat::TaskResolution tr = openai_compat::resolve_task(request);
+        using TRS = openai_compat::TaskResolution::Status;
+
+        const openai_compat::TaskPolicy policy =
+            openai_compat::task_policy(supports_prompts, !declared.empty(), tr.status != TRS::Absent);
+        if (policy == openai_compat::TaskPolicy::NotSupported) {
+            // prompt_for() returns an empty prefix for a model with no prompt table,
+            // so this used to answer 200 with an UNPREFIXED vector -- correctly
+            // shaped, correctly normed, and not what was asked for.
+            // src/open_npue_adapter/README.md: "model has no prompts, a prompt is
+            // given | error".
+            send_response(json{{"error", {
+                {"message", "model '" + model + "' has no task prompts; remove '" + tr.field +
+                            "'. Passing one would be ignored, and the vector would come back "
+                            "correctly shaped and unprefixed with nothing to show it."},
+                {"type", "invalid_request_error"}, {"param", tr.field}, {"code", "invalid_value"}}}});
+            return;
+        }
+        if (policy == openai_compat::TaskPolicy::Required) {
+            std::string names;
+            for (const auto& n : declared) names += (names.empty() ? "" : ", ") + n;
+            // Quote the REST vocabulary, not `declared`: the validator only accepts
+            // the former, so naming the latter sent clients to values it refuses.
+            json err = { {"error", {
+                {"message", "this model requires a task prompt: pass 'prompt_name' as "
+                            "one of [" + accepted + "] (this model declares the prompts [" +
+                            names + "], which those names map onto). Refusing to pick one -- "
+                            "the prefix changes the vector (search_query against "
+                            "search_document on the same text is cosine 0.914 here), and the "
+                            "result is correctly shaped, correctly normed and deterministic "
+                            "either way, so nothing downstream can tell the wrong one was used."},
+                {"type", "invalid_request_error"},
+                {"param", "prompt_name"},
+                {"code", "missing_required_parameter"}
+            }} };
+            send_response(err);
+            return;
+        }
+        if (tr.status == TRS::NotAString) {
+            send_response(json{{"error", {
+                {"message", "'" + tr.field + "' must be a string, one of [" + accepted + "]"},
+                {"type", "invalid_request_error"}, {"param", tr.field}, {"code", "invalid_value"}}}});
+            return;
+        }
+        if (tr.status == TRS::Unknown) {
+            send_response(json{{"error", {
+                {"message", "unknown " + tr.field + " '" + tr.value + "'. Known: [" + accepted +
+                            "]. Refusing to substitute one: an embedding under the wrong task "
+                            "prompt is correctly shaped and correctly normed, so nothing "
+                            "downstream can tell it is wrong."},
+                {"type", "invalid_request_error"}, {"param", tr.field}, {"code", "invalid_value"}}}});
+            return;
+        }
+        if (tr.status == TRS::Conflict) {
+            send_response(json{{"error", {
+                {"message", "'prompt_name' and 'task_type' are aliases and disagree "
+                            "('task_type' says '" + tr.value + "'). Send one, or send the same "
+                            "task in both."},
+                {"type", "invalid_request_error"}, {"param", tr.field}, {"code", "invalid_value"}}}});
+            return;
+        }
+        if (tr.status == TRS::Ok) task_type = tr.task;
 
         std::vector<std::string> inputs;
 

--- a/src/server/rest_handler.cpp
+++ b/src/server/rest_handler.cpp
@@ -465,6 +465,7 @@ RestHandler::ModelLoad RestHandler::ensure_model_loaded(const std::string& model
         auto_chat_engine->configure_parameter("img_pre_resize", this->img_pre_resize);
         try {
             auto_chat_engine->load_model(supported_models.get_model_path(new_ensure_tag), model_info, ctx_length, preemption);
+            auto_chat_engine->snapshot_request_defaults();
         }
         catch (const std::exception& e) {
             header_print("ERROR", "Failed to load model: " + std::string(e.what()));
@@ -555,6 +556,8 @@ void RestHandler::ensure_embed_model_loaded(const std::string& model_tag) {
 ///@param options the options JSON object
 ///@param request the request JSON object
 void RestHandler::configure_chat_engine_parameters(const json& options, const json& request) {
+    // a field the request leaves out means the model default, not the previous request's value
+    auto_chat_engine->reset_request_defaults();
     if (request.contains("temperature")) {
         float temperature = request["temperature"];
         auto_chat_engine->set_temperature(temperature);

--- a/src/server/rest_handler.cpp
+++ b/src/server/rest_handler.cpp
@@ -460,6 +460,22 @@ RestHandler::ModelLoad RestHandler::ensure_model_loaded(const std::string& model
             this->current_model_tag = "model-faker";
             return ModelLoad::NotChatModel;
         }
+        // A request may name a model that is in the list but not on disk, or one an update
+        // has left behind - pull it before loading rather than failing the request.
+        switch (downloader.is_model_downloaded(ensure_tag)) {
+            case ModelDownloader::ModelStatus::Ready:
+                break;
+            case ModelDownloader::ModelStatus::Outdated:
+            case ModelDownloader::ModelStatus::Missing:
+                downloader.pull_model(ensure_tag, this->modelscope);
+                break;
+            case ModelDownloader::ModelStatus::Incompatible:
+                header_print("ERROR", "model '" + ensure_tag + "' is not compatible with this "
+                                      "version of OpenFlowLM; nothing is loaded now");
+                this->auto_chat_engine.reset();
+                this->current_model_tag = "model-faker";
+                return ModelLoad::LoadFailed;
+        }
         auto [new_ensure_tag, model_info] = supported_models.get_model_info(ensure_tag);
         auto_chat_engine->configure_parameter("img_pre_resize", this->img_pre_resize);
         try {

--- a/src/test/gemma4_tool_parser/CMakeLists.txt
+++ b/src/test/gemma4_tool_parser/CMakeLists.txt
@@ -3,7 +3,8 @@ project(gemma4_tool_parser VERSION 1.0.0 LANGUAGES CXX)
 
 # Header-only parser test: no NPU, no XRT, no model. Configure and run with
 #   cmake -S src/test/gemma4_tool_parser -B src/build/test_gemma4_tool_parser -G Ninja
-#   cmake --build src/build/test_gemma4_tool_parser && src/build/test/gemma4_tool_parser/test_gemma4_tool_parser.exe
+#   cmake --build src/build/test_gemma4_tool_parser
+#   ctest --test-dir src/build/test_gemma4_tool_parser --output-on-failure
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/src/test/gemma4_tool_parser/CMakeLists.txt
+++ b/src/test/gemma4_tool_parser/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.22)
+project(gemma4_tool_parser VERSION 1.0.0 LANGUAGES CXX)
+
+# Header-only parser test: no NPU, no XRT, no model. Configure and run with
+#   cmake -S src/test/gemma4_tool_parser -B src/build/test_gemma4_tool_parser -G Ninja
+#   cmake --build src/build/test_gemma4_tool_parser && src/build/test/gemma4_tool_parser/test_gemma4_tool_parser.exe
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/../../build/test/gemma4_tool_parser)
+
+add_executable(test_gemma4_tool_parser test.cpp)
+target_include_directories(test_gemma4_tool_parser PRIVATE ${CMAKE_SOURCE_DIR}/../../include)
+if(MSVC)
+    target_compile_options(test_gemma4_tool_parser PRIVATE /utf-8 /EHsc)
+endif()
+
+enable_testing()
+add_test(NAME gemma4_tool_parser COMMAND test_gemma4_tool_parser)

--- a/src/test/gemma4_tool_parser/test.cpp
+++ b/src/test/gemma4_tool_parser/test.cpp
@@ -1,0 +1,108 @@
+// Traces: TOOLS-GEMMA4-ENVELOPE, TOOLS-GEMMA4-SCHEMA-TYPES (canonical spec: specs/tool-calling/spec.md)
+// Unit tests for the shared Gemma 4 tool-call parser. Header-only, no NPU, no model.
+#include "AutoModel/gemma4_tool_parser.hpp"
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+using gemma4_tools::json;
+
+static int failures = 0;
+
+#define CHECK(cond)                                                               \
+    do {                                                                          \
+        if (!(cond)) {                                                            \
+            std::cerr << "FAIL " << __FILE__ << ":" << __LINE__ << ": " #cond << "\n"; \
+            ++failures;                                                           \
+        }                                                                         \
+    } while (0)
+
+static void test_direct_call() {
+    auto [name, args] = gemma4_tools::parse_tool_call("call:get_current_weather{location:<|\"|>Paris<|\"|>}");
+    CHECK(name == "get_current_weather");
+    CHECK(args == json({{"location", "Paris"}}));
+}
+
+static void test_no_args() {
+    auto [name, args] = gemma4_tools::parse_tool_call("call:get_time{}");
+    CHECK(name == "get_time");
+    CHECK(args.is_object() && args.empty());
+}
+
+static void test_nested_values() {
+    auto [name, args] = gemma4_tools::parse_tool_call(
+        "call:create_event{attendees:[{email:<|\"|>a@x.com<|\"|>,optional:true},{email:<|\"|>b@x.com<|\"|>}],"
+        "title:<|\"|>Sync<|\"|>,when:{date:<|\"|>2026-09-12<|\"|>,time:<|\"|>10:00<|\"|>},count:3}");
+    CHECK(name == "create_event");
+    CHECK(args["attendees"].size() == 2);
+    CHECK(args["attendees"][0]["optional"] == true);
+    CHECK(args["when"]["time"] == "10:00");
+    CHECK(args["count"] == 3);
+}
+
+static void test_envelope_from_issue_722() {
+    // the trace from ROCm/FastFlowLM#722, verbatim shape
+    auto [name, args] = gemma4_tools::parse_tool_call(
+        "call:tool_call{args:{query:\"тренировки на пресс или ноги\"},id:<|\"|>memory_search<|\"|>}");
+    CHECK(name == "memory_search");
+    CHECK(args == json({{"query", "тренировки на пресс или ноги"}}));
+}
+
+static void test_envelope_name_arguments_variant() {
+    auto [name, args] = gemma4_tools::parse_tool_call(
+        "call:function{name:<|\"|>lookup_item_price<|\"|>,arguments:{item:<|\"|>widget<|\"|>}}");
+    CHECK(name == "lookup_item_price");
+    CHECK(args == json({{"item", "widget"}}));
+}
+
+static void test_envelope_without_inner_name_is_left_alone() {
+    // a real tool that happens to be called tool_call with plain args must not be rewritten
+    auto [name, args] = gemma4_tools::parse_tool_call("call:tool_call{query:<|\"|>x<|\"|>}");
+    CHECK(name == "tool_call");
+    CHECK(args == json({{"query", "x"}}));
+}
+
+static void test_schema_type_array_becomes_nullable_scalar() {
+    json tools = json::parse(R"([{"type":"function","function":{"name":"search_notes","parameters":{
+        "type":"object","properties":{
+            "query":{"type":"string"},
+            "folder":{"type":["string","null"],"description":"Folder or null"},
+            "tags":{"type":"array","items":{"type":["integer","null"]}},
+            "opts":{"type":"object","properties":{"deep":{"type":["null","boolean"]}}}
+        },"required":["query"]}}}])");
+    json out = gemma4_tools::normalize_tools(tools);
+    auto& props = out[0]["function"]["parameters"]["properties"];
+    CHECK(props["query"]["type"] == "string");
+    CHECK(props["folder"]["type"] == "string");
+    CHECK(props["folder"]["nullable"] == true);
+    CHECK(props["folder"]["description"] == "Folder or null");
+    CHECK(props["tags"]["items"]["type"] == "integer");
+    CHECK(props["tags"]["items"]["nullable"] == true);
+    CHECK(props["opts"]["properties"]["deep"]["type"] == "boolean");
+    CHECK(props["opts"]["properties"]["deep"]["nullable"] == true);
+    // untouched input: scalar types and the original object are not modified
+    CHECK(tools[0]["function"]["parameters"]["properties"]["folder"]["type"].is_array());
+}
+
+static void test_schema_without_arrays_is_unchanged() {
+    json tools = json::parse(R"([{"type":"function","function":{"name":"f","parameters":{
+        "type":"object","properties":{"a":{"type":"string","enum":["x","y"]}},"required":["a"]}}}])");
+    CHECK(gemma4_tools::normalize_tools(tools) == tools);
+}
+
+int main() {
+    test_direct_call();
+    test_no_args();
+    test_nested_values();
+    test_envelope_from_issue_722();
+    test_envelope_name_arguments_variant();
+    test_envelope_without_inner_name_is_left_alone();
+    test_schema_type_array_becomes_nullable_scalar();
+    test_schema_without_arrays_is_unchanged();
+    if (failures) {
+        std::cerr << failures << " check(s) failed\n";
+        return EXIT_FAILURE;
+    }
+    std::cout << "gemma4_tool_parser: all checks passed\n";
+    return EXIT_SUCCESS;
+}

--- a/src/test/gemma4_tool_parser/test.cpp
+++ b/src/test/gemma4_tool_parser/test.cpp
@@ -62,6 +62,15 @@ static void test_envelope_without_inner_name_is_left_alone() {
     CHECK(args == json({{"query", "x"}}));
 }
 
+static void test_tool_named_function_with_a_name_argument_is_left_alone() {
+    // a tool really called `function` whose own arguments include `name`: the extra
+    // argument proves this is not an envelope, so nothing may be renamed or dropped
+    auto [name, args] = gemma4_tools::parse_tool_call(
+        "call:function{name:<|\"|>widget<|\"|>,quantity:2}");
+    CHECK(name == "function");
+    CHECK(args == json({{"name", "widget"}, {"quantity", 2}}));
+}
+
 static void test_schema_type_array_becomes_nullable_scalar() {
     json tools = json::parse(R"([{"type":"function","function":{"name":"search_notes","parameters":{
         "type":"object","properties":{
@@ -97,6 +106,7 @@ int main() {
     test_envelope_from_issue_722();
     test_envelope_name_arguments_variant();
     test_envelope_without_inner_name_is_left_alone();
+    test_tool_named_function_with_a_name_argument_is_left_alone();
     test_schema_type_array_becomes_nullable_scalar();
     test_schema_without_arrays_is_unchanged();
     if (failures) {

--- a/utilities/oflm-test/README.md
+++ b/utilities/oflm-test/README.md
@@ -10,7 +10,7 @@ oflm-test is designed to thoroughly test OpenFlowLM's API compatibility and mode
 - **Embedding Tests**: Text embedding validation (structure, determinism, batching, dimensionality, semantic ordering, model identity) with automated check verdicts. Runs exclusively on a server loaded with only an embed model (`oflm serve -e 1`, or `oflm serve <llm> --embed 1 --embeddingmodel <tag>` for a tag served by the `open_npue` backend).
 - **Audio Tests**: Audio understanding via chat completions, with a bundled music clip
 - **Vision Tests**: Vision-Language Model (VLM) tests with multi-image support and automated response checking
-- **Tool Calling Tests**: Function/tool-calling across five escalating complexity levels, in streaming and non-streaming modes
+- **Tool Calling Tests**: Function/tool-calling across seven escalating complexity levels, in streaming and non-streaming modes
 
 All test media is **bundled inside the package**, so no extra downloads or local paths are needed once installed.
 

--- a/utilities/oflm-test/README.md
+++ b/utilities/oflm-test/README.md
@@ -251,7 +251,7 @@ Because this suite is exclusive, only an embedding model is loaded on the server
 **Output:** `embedding_results_v{version}_{timestamp}.csv`
 
 ### Tool Calling Tests
-Tests OpenAI-compatible function/tool-calling across five escalating complexity levels. Each level runs in both **non-streaming** and **streaming** mode.
+Tests OpenAI-compatible function/tool-calling across seven escalating complexity levels. Each level runs in both **non-streaming** and **streaming** mode.
 
 **What it tests:**
 - Emitting well-formed tool calls with valid JSON arguments (streamed and non-streamed)
@@ -259,6 +259,8 @@ Tests OpenAI-compatible function/tool-calling across five escalating complexity 
 - Restraint: not calling tools when none are needed (negative control)
 - Parallel tool calls for multiple independent requests in one turn
 - The full tool loop: call → locally executed result → final answer grounded in the result
+- Tool result fidelity: a value in the last few tokens of a tool result comes back verbatim (catches prompt trimming that eats the tail of the result)
+- Schema robustness: a tool whose parameter uses a JSON-schema type array (`["string", "null"]`) still renders and gets called
 
 | Level | Name | Scenario |
 |-------|------|----------|
@@ -267,6 +269,8 @@ Tests OpenAI-compatible function/tool-calling across five escalating complexity 
 | L3 | Tool Restraint | Capital-of-France question with tools bound; nothing should be called |
 | L4 | Parallel Tool Calls | Compare current weather in Paris and Tokyo in one turn |
 | L5 | Multi-Turn Tool Loop | Look up widget price via a tool, then compute 3 widgets at 10% discount |
+| L6 | Tool Result Fidelity | A completed `get_ticket` call whose result ends in `zz_code: ZQX-7731`; the model must echo that code |
+| L7 | Nullable Schema | Search notes with a `folder` parameter typed `["string", "null"]`; the request must succeed and call `search_notes` |
 
 Tool results in L5 are produced by built-in mock implementations (deterministic fake weather/price databases), so no external services are required. Widget price is $20.00, so a correct final answer contains **54** (3 × $20 − 10%).
 
@@ -278,6 +282,8 @@ Tool results in L5 are produced by built-in mock implementations (deterministic 
 | L4 Parallel Check | PASS / SOFT-FAIL / FAIL | At least two calls covering both cities; SOFT-FAIL if only one call was issued |
 | L5 Lookup Check | PASS / FAIL | `lookup_item_price` called with item 'widget' |
 | L5 Final Answer Check | PASS / FAIL | Final answer reflects the computed total of $54 |
+| L6 Fidelity Check | PASS / FAIL | Answer contains `ZQX-7731` and no further tool call was made |
+| L7 Nullable Check | PASS / FAIL | `search_notes` called with a query mentioning 'budget'; an HTTP error from the server is a FAIL |
 
 **Output:** `tools_results_v{version}_{timestamp}.csv`
 

--- a/utilities/oflm-test/oflm_test/__init__.py
+++ b/utilities/oflm-test/oflm_test/__init__.py
@@ -48,7 +48,7 @@ def main():
     parser.add_argument('--audio', action='store_true', help="Run Audio tests")
     parser.add_argument('--vision', action='store_true', help="Run vision tests")
     parser.add_argument('--tools', action='store_true',
-                        help="Run tool-calling tests (five complexity levels)")
+                        help="Run tool-calling tests (seven complexity levels)")
     parser.add_argument('--all', action='store_true',
                         help="Run all suites except embedding (which stays exclusive)")
     parser.add_argument('--gen-lim', type=int, default=-1, help="Maximum number of tokens to generate")

--- a/utilities/oflm-test/oflm_test/tasks.py
+++ b/utilities/oflm-test/oflm_test/tasks.py
@@ -900,7 +900,7 @@ class VisionTask(BaseTestTask):
 
 class ToolCallingTask(BaseTestTask):
     """
-    Tests OpenAI-compatible function/tool calling at five escalating
+    Tests OpenAI-compatible function/tool calling at seven escalating
     complexity levels, each run in both streaming and non-streaming mode:
 
       L1 Basic Tool Call      One obvious call whose arguments appear verbatim
@@ -912,6 +912,11 @@ class ToolCallingTask(BaseTestTask):
       L4 Parallel Tool Calls  Several independent calls belong in one turn.
       L5 Multi-Turn Tool Loop The model must call a tool, consume the locally
                               executed result, and ground its final answer in it.
+      L6 Tool Result Fidelity A code in the last few tokens of a tool result must
+                              come back verbatim, which prompt trimming that eats
+                              the tail of the result would break.
+      L7 Nullable Schema      A parameter typed ["string", "null"] must not fail
+                              the request, and the tool must still be called.
 
     Automated checks validate tool names, JSON argument validity/values and,
     for L5, the arithmetic derived from the tool result ($54 total).

--- a/utilities/oflm-test/oflm_test/tasks.py
+++ b/utilities/oflm-test/oflm_test/tasks.py
@@ -982,6 +982,40 @@ class ToolCallingTask(BaseTestTask):
     PARALLEL_PROMPT = "Using your tools, compare the current weather in Paris and Tokyo."
     LOOP_PROMPT = ("Use the price lookup tool to check the unit price of a 'widget', then tell me "
                    "what 3 widgets would cost after a 10% discount. Do the math yourself.")
+    # L6: the value the model must repeat sits in the last few tokens of the tool result
+    # (templates that sort keys put zz_code last), so any truncation of the result shows up.
+    FIDELITY_PROMPT = ("Fetch ticket 42 and reply with ONLY the exact value of its `zz_code` field, "
+                       "nothing else.")
+    FIDELITY_TOOL = {
+        "type": "function",
+        "function": {
+            "name": "get_ticket",
+            "description": "Fetch a support ticket by id.",
+            "parameters": {
+                "type": "object",
+                "properties": {"ticket_id": {"type": "string", "description": "Ticket id, e.g. '42'."}},
+                "required": ["ticket_id"],
+            },
+        },
+    }
+    FIDELITY_RESULT = {"a_status": "open", "zz_code": "ZQX-7731"}
+    # L7: a JSON-schema type array, the shape Pydantic optionals and most MCP servers emit
+    NULLABLE_PROMPT = "Search my notes for 'budget' in any folder. Use the tool."
+    NULLABLE_TOOL = {
+        "type": "function",
+        "function": {
+            "name": "search_notes",
+            "description": "Search the user's notes.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string", "description": "Search text."},
+                    "folder": {"type": ["string", "null"], "description": "Folder to search, or null for all."},
+                },
+                "required": ["query"],
+            },
+        },
+    }
 
     LEVEL_NAMES = [
         "L1 Basic Tool Call",
@@ -989,6 +1023,8 @@ class ToolCallingTask(BaseTestTask):
         "L3 Tool Restraint",
         "L4 Parallel Tool Calls",
         "L5 Multi-Turn Tool Loop",
+        "L6 Tool Result Fidelity",
+        "L7 Nullable Schema",
     ]
 
     FINAL_ANSWER_PATTERN = re.compile(r"\b54(\.0{1,2})?\b")
@@ -1081,12 +1117,13 @@ class ToolCallingTask(BaseTestTask):
                       for _, entry in sorted(accumulated.items())]
         return reasoning_content, output_content, tool_calls
 
-    def _call_model(self, model_id, messages, stream, max_completion_tokens, temperature, reasoning=None):
+    def _call_model(self, model_id, messages, stream, max_completion_tokens, temperature, reasoning=None,
+                    tools=None):
         """One chat completion with tools bound; returns (reasoning, content, tool_calls)."""
         response = self.client.chat.completions.create(
             model=model_id,
             messages=messages,
-            tools=self.TOOLS,
+            tools=tools if tools is not None else self.TOOLS,
             stream=stream,
             max_completion_tokens=max_completion_tokens,
             temperature=temperature,
@@ -1250,6 +1287,73 @@ class ToolCallingTask(BaseTestTask):
                             f"ERROR: {e}", "N/A", [], "ERROR")
         time.sleep(1)
 
+    def _check_fidelity(self, content, tool_calls):
+        """L6: the tail value of the tool result is reproduced verbatim, with no further call."""
+        if tool_calls:
+            return ("FAIL", f"called {[tc['name'] for tc in tool_calls]} instead of answering from the result")
+        if self.FIDELITY_RESULT["zz_code"] in (content or ""):
+            return ("PASS", "tool result reached the model intact")
+        return ("FAIL", f"expected '{self.FIDELITY_RESULT['zz_code']}' in the answer, got '{(content or '')[:80]}'")
+
+    def _check_nullable(self, content, tool_calls):
+        """L7: the request survives a type-array schema and the tool gets called."""
+        if not tool_calls:
+            return ("FAIL", "no tool call issued")
+        first = tool_calls[0]
+        if first["name"] != "search_notes":
+            return ("FAIL", f"expected 'search_notes', got '{first['name'] or '<empty>'}'")
+        args = self._parse_arguments(first["arguments"])
+        if args is None:
+            return ("FAIL", "tool arguments are not a valid JSON object")
+        if "budget" not in str(args.get("query", "")).lower():
+            return ("FAIL", f"expected query to mention 'budget', got '{args.get('query')}'")
+        return ("PASS", f"called search_notes with query '{args.get('query')}'")
+
+    def _run_fidelity_level(self, writer, model_id, stream, max_completion_tokens, temperature, reasoning=None):
+        level_name = self.LEVEL_NAMES[5]
+        mode = "Stream" if stream else "Non-Stream"
+        messages = [
+            {"role": "user", "content": self.FIDELITY_PROMPT},
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "call_fidelity_1", "type": "function",
+                 "function": {"name": "get_ticket", "arguments": json.dumps({"ticket_id": "42"})}}]},
+            {"role": "tool", "tool_call_id": "call_fidelity_1", "content": json.dumps(self.FIDELITY_RESULT)},
+        ]
+        label = f"{self.FIDELITY_PROMPT} [with tool result fed back]"
+        try:
+            print(f"{level_name}: {self.FIDELITY_PROMPT}")
+            reasoning_content, content, tool_calls = self._call_model(
+                model_id, messages, stream, max_completion_tokens, temperature, reasoning,
+                tools=self.TOOLS + [self.FIDELITY_TOOL])
+            verdict = self._check_fidelity(content, tool_calls)
+            self._write_row(writer, model_id, level_name, mode, label,
+                            reasoning_content, content, tool_calls, verdict)
+            print(f"Check result: {verdict[0]} ({verdict[1]})")
+        except Exception as e:
+            print(f"Error occurred in {level_name}, model: {model_id}: {e}")
+            self._write_row(writer, model_id, level_name, mode, label, f"ERROR: {e}", "N/A", [], "ERROR")
+        time.sleep(1)
+
+    def _run_nullable_level(self, writer, model_id, stream, max_completion_tokens, temperature, reasoning=None):
+        level_name = self.LEVEL_NAMES[6]
+        mode = "Stream" if stream else "Non-Stream"
+        messages = [{"role": "user", "content": self.NULLABLE_PROMPT}]
+        try:
+            print(f"{level_name}: {self.NULLABLE_PROMPT}")
+            reasoning_content, content, tool_calls = self._call_model(
+                model_id, messages, stream, max_completion_tokens, temperature, reasoning,
+                tools=self.TOOLS + [self.NULLABLE_TOOL])
+            verdict = self._check_nullable(content, tool_calls)
+            self._write_row(writer, model_id, level_name, mode, self.NULLABLE_PROMPT,
+                            reasoning_content, content, tool_calls, verdict)
+            print(f"Check result: {verdict[0]} ({verdict[1]})")
+        except Exception as e:
+            # a template that cannot render the schema comes back as an HTTP error, which is the failure
+            print(f"Error occurred in {level_name}, model: {model_id}: {e}")
+            self._write_row(writer, model_id, level_name, mode, self.NULLABLE_PROMPT,
+                            f"ERROR: {e}", "N/A", [], ("FAIL", f"request failed: {str(e)[:120]}"))
+        time.sleep(1)
+
     def run(self, max_completion_tokens=-1, temperature=0.3, reasoning=None):
         single_round_levels = [
             (self.LEVEL_NAMES[0], self.BASIC_PROMPT,
@@ -1278,5 +1382,9 @@ class ToolCallingTask(BaseTestTask):
                                                      reasoning=reasoning)
                     self._run_loop_level(writer, model_id, stream, max_completion_tokens, temperature,
                                          reasoning=reasoning)
+                    self._run_fidelity_level(writer, model_id, stream, max_completion_tokens, temperature,
+                                             reasoning=reasoning)
+                    self._run_nullable_level(writer, model_id, stream, max_completion_tokens, temperature,
+                                             reasoning=reasoning)
                 print(f"Finished testing model: {model_id}")
         print(f"\nTool calling tests complete. Saved to {self.csv_filename}")


### PR DESCRIPTION
A user on the FastFlowLM tracker said Gemma 4 12B calls tools far worse than Qwen 3.6 does. They are right, and it is not the model. `oflm-test --tools` passes the 12B twelve checks out of twelve, so the suite was missing what agent clients actually hit. Three bugs, all in the shared `AutoModel` and server layer rather than in kernels, so they apply whichever engine runs the weights.

**Every tool result reached the model four tokens short.** With thinking off, the chat template ends a normal turn with an empty thought block, and the engine trims those four tokens off the prefill so it can feed them back after its checkpoint. After a tool result the template ends the prompt at the tool-response marker and writes no thought block, but the trim ran anyway. It ate the last four tokens of the result and injected a thought block the template never wrote. At temperature 0, a result ending in `"zz_code": "ZQX-7731"` prefilled 129 of its 133 tokens and came back as `ZQX-773`; a weather result of 18 degrees was reported as 15. The trim now happens only when the rendered prompt really ends with that block. This is the one I think explains the complaint: it corrupts every tool result in the default mode.

**A tool parameter typed `["string", "null"]` failed the whole request.** The template upper-cases every parameter type. Python's Jinja quietly stringifies a list there; minja throws, and the exception is what the client gets back, on every request carrying such a tool rather than only the ones that want it. Pydantic optionals and most MCP servers emit exactly that shape. Tool schemas are now folded to the first non-null type plus `nullable: true`, a key the template already understands, so the template stays exactly as Google shipped it.

**A wrapped call lost its name.** The model sometimes wraps the real call in a generic envelope, and the parser returned `tool_call` as the function name, so the client drops a call it cannot match. That is ROCm/FastFlowLM#722. I could not reproduce it here in three tries, but the reporter's trace is unambiguous and the unwrap is small and hard to misfire.

While in there, the Gemma 4 tool-call parser existed twice, once per model file, four hundred identical lines each. It is now one header that both include, which is also what makes it unit-testable.

The second commit is a separate bug found the same afternoon: settings a request does not carry were left at whatever the previous request set, so one client asking for `reasoning_effort: low` turned thinking on for everyone else. It fooled my own first probe into looking clean.

**Verification.** New unit tests for the parser (no NPU needed, standalone CMake project under `src/test/gemma4_tool_parser/`). Four new integration tests under `specs/tool-calling/tests/`, which skip with a reason when no server is listening; they pass against `gemma4-it:12b` on Strix. `oflm-test --tools` still passes, now with two extra levels that fail on the old binary: L6 checks that a value in the last tokens of a tool result survives, L7 binds a tool with a type array.

**What I would like looked at.** The trim condition keys off the rendered prompt ending with the empty thought block. That is the honest signal, but if you would rather it keyed off something the template states outright, say so and I will change it. The E-series models share the parser but not the trim, because they ship the older template; when they move to the canonical one they need the guarded version, not the old unconditional one. And this adds a new requirement prefix under `specs/tool-calling/` for behaviour that is not the open engine's, so tell me if you would rather it lived somewhere else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
