### PR TITLE
Server: a mid-stream generate() failure is reported in-stream and ends the stream

### DIFF
--- a/src/server/openai_compat.hpp
+++ b/src/server/openai_compat.hpp
@@ -237,4 +237,74 @@ inline TaskPolicy task_policy(bool supports_prompts, bool declares_names, bool t
     return TaskPolicy::Ok;
 }
 
+/// What a streaming response has already handed to the transport (#64).
+///
+/// The first frame sends the 200 and the chunked headers, so from then on
+/// send_response() cannot reach the client: HttpSession skips write_response() for a
+/// streaming session, so an error body went nowhere and the connection was never
+/// terminated -- or, for a queued request, a second HTTP response was written into
+/// the chunked body. The final frame ends the stream, and it is also what advances
+/// the NPU queue, so nothing may follow it either.
+struct StreamState {
+    bool opened = false;  ///< a frame has been, or was being, handed to the transport
+    bool closed = false;  ///< a final frame's send has RETURNED
+};
+
+/// Send one frame through `send()` and record it in `s`.
+///
+/// `opened` is set before the send, because once a send has started the headers may be
+/// on the wire. `closed` is set only after it returns: a final send that throws has
+/// neither ended the stream nor advanced the NPU queue, so the error must still go
+/// in-stream. Marking it closed first dropped that error as unreportable, and the queue
+/// never moved again. Exceptions propagate unchanged.
+template <class Send>
+inline void send_tracked(StreamState& s, bool is_final, Send&& send) {
+    s.opened = true;
+    send();
+    if (is_final) s.closed = true;
+}
+
+/// Where an error raised by a streaming handler has to go.
+enum class ErrorRoute {
+    Body,         ///< nothing is on the wire yet: an ordinary error body, with its status
+    Frame,        ///< the stream is open: report in-stream, then end the stream
+    Unreportable  ///< the stream has ended: there is no transport left to report on
+};
+
+inline ErrorRoute error_route(const StreamState& s) {
+    if (!s.opened) return ErrorRoute::Body;
+    return s.closed ? ErrorRoute::Unreportable : ErrorRoute::Frame;
+}
+
+/// The two streaming formats this server speaks.
+enum class StreamWire {
+    Sse,     ///< /v1/*: `data: <json>\n\n` events, terminated by `data: [DONE]`
+    Ndjson   ///< /api/*: one JSON object per line, no terminator event
+};
+
+/// The frames that report `message` inside an open stream, in order. The caller sends
+/// the last one as final.
+///
+/// SSE carries OpenAI's error object, which is what its clients look for in a stream
+/// (openai-python raises APIError on a data event with an "error" key), followed by
+/// [DONE] so a client waiting for the terminator gets one. NDJSON carries Ollama's
+/// `{"error": "<text>"}`, the shape its client checks for on every line.
+///
+/// Serialised with error_handler_t::replace: `message` is an exception's what(), and
+/// a json::parse_error quotes the bytes it choked on. A strict dump() would throw on
+/// invalid UTF-8 from inside the catch block that is reporting it.
+inline std::vector<std::string> stream_error_frames(StreamWire wire, const std::string& message) {
+    if (wire == StreamWire::Sse) {
+        const json body = {{"error", {
+            {"message", message},
+            {"type", "server_error"},
+            {"code", 500}
+        }}};
+        return {"data: " + body.dump(-1, ' ', false, json::error_handler_t::replace) + "\n\n",
+                "data: [DONE]\n\n"};
+    }
+    const json body = {{"error", message}};
+    return {body.dump(-1, ' ', false, json::error_handler_t::replace) + "\n"};
+}
+
 }  // namespace openai_compat

--- a/src/server/openai_compat_test.cpp
+++ b/src/server/openai_compat_test.cpp
@@ -16,7 +16,10 @@
 #include <cstdio>
 #include <cstdlib>
 #include <filesystem>
+#include <functional>
+#include <stdexcept>
 #include <string>
+#include <vector>
 
 #include "AutoModel/model_families.hpp"
 #include "server/openai_compat.hpp"
@@ -389,6 +392,128 @@ static void test_task_policy() {
        "no combination lets a task reach a backend that does not honour it");
 }
 
+// ---------------------------------------------------------------------------
+// Errors in a streaming handler (#64).
+//
+// The bug: an exception out of generate() after tokens had streamed went through
+// send_response(). The 200 and the chunked headers were already on the wire, so the
+// body was never written (HttpSession skips write_response() once streaming) and the
+// stream was never ended -- the client waited for a [DONE] that did not come.
+// ---------------------------------------------------------------------------
+static void test_stream_errors() {
+    using openai_compat::error_route;
+    using openai_compat::stream_error_frames;
+    using openai_compat::StreamState;
+    using openai_compat::StreamWire;
+    using R = openai_compat::ErrorRoute;
+    using json = openai_compat::json;
+    std::printf("\n-- stream errors --\n");
+
+    using openai_compat::send_tracked;
+    int sent = 0;
+    auto send_ok = [&] { ++sent; };
+    auto send_throws = [&] { ++sent; throw std::runtime_error("write failed"); };
+
+    StreamState s;
+    ok(error_route(s) == R::Body,
+       "nothing sent yet: an ordinary error body, which is still correct before the first frame");
+    send_tracked(s, false, send_ok);
+    ok(error_route(s) == R::Frame, "after a token frame: the error goes in-stream");
+    send_tracked(s, false, send_ok);
+    ok(error_route(s) == R::Frame, "...after any number of them");
+    send_tracked(s, true, send_ok);
+    ok(error_route(s) == R::Unreportable,
+       "after the final frame: nothing, because the stream has ended and the queue has moved on");
+    send_tracked(s, false, send_ok);
+    ok(error_route(s) == R::Unreportable, "...and a frame after the final one does not reopen it");
+    eqi(sent, 4, "send_tracked calls the send exactly once per frame");
+
+    StreamState only_final;
+    send_tracked(only_final, true, send_ok);
+    ok(error_route(only_final) == R::Unreportable,
+       "a final frame that is also the first still ends the stream");
+
+    // The review finding: a FINAL send that throws has not ended the stream and has
+    // not advanced the NPU queue. Recording it as closed before the send made the
+    // handler drop the error -- and nothing ever released the NPU.
+    auto threw = [](StreamState& st, bool is_final, const std::function<void()>& send) {
+        try {
+            send_tracked(st, is_final, send);
+        } catch (const std::runtime_error&) {
+            return true;
+        }
+        return false;
+    };
+    StreamState final_throws;
+    send_tracked(final_throws, false, send_ok);
+    ok(threw(final_throws, true, send_throws), "a throwing send propagates its exception");
+    ok(error_route(final_throws) == R::Frame,
+       "a FINAL send that threw leaves the stream open, so the error still goes in-stream");
+    StreamState first_throws;
+    ok(threw(first_throws, false, send_throws), "...a throwing first send propagates too");
+    ok(error_route(first_throws) == R::Frame,
+       "a first send that threw counts as opened: its headers may already be on the wire");
+
+    // SSE: OpenAI's error object, then the terminator.
+    auto sse = stream_error_frames(StreamWire::Sse, "NPU fault");
+    eqi(static_cast<int>(sse.size()), 2, "SSE: an error event and a terminator");
+    if (sse.size() == 2) {
+        const std::string& ev = sse[0];
+        const bool framed = ev.rfind("data: ", 0) == 0 && ev.size() >= 8 &&
+                            ev.compare(ev.size() - 2, 2, "\n\n") == 0;
+        ok(framed, "SSE: the error is one `data: ...\\n\\n` event");
+        if (framed) {
+            json body = json::parse(ev.substr(6, ev.size() - 8), nullptr, false);
+            ok(body.is_object() && body.contains("error") && body["error"].is_object(),
+               "SSE: the event carries an error OBJECT, which is what OpenAI clients look for");
+            if (body.is_object() && body.contains("error") && body["error"].is_object()) {
+                eq(body["error"].value("message", ""), "NPU fault", "SSE: the message is the exception's");
+                eq(body["error"].value("type", ""), "server_error", "SSE: type server_error");
+                eqi(openai_compat::status_for(body), 500,
+                    "SSE: the same body read as a response is a 500, as the Body route would say");
+            }
+        }
+        eq(sse[1], "data: [DONE]\n\n", "SSE: the stream ends with [DONE], last");
+    }
+
+    // A newline pair in the message must not end the event early.
+    auto sse_nl = stream_error_frames(StreamWire::Sse, "line one\n\nline two");
+    ok(!sse_nl.empty() && sse_nl[0].find("\n\n") == sse_nl[0].size() - 2,
+       "SSE: a blank line in the message does not split the event");
+
+    // NDJSON: Ollama's {"error": "<text>"}, one line, no SSE prefix.
+    auto nd = stream_error_frames(StreamWire::Ndjson, "NPU fault\nsecond line");
+    eqi(static_cast<int>(nd.size()), 1, "NDJSON: one line, which the caller sends as final");
+    if (nd.size() == 1) {
+        const std::string& line = nd[0];
+        ok(!line.empty() && line.back() == '\n' && line.find('\n') == line.size() - 1,
+           "NDJSON: exactly one newline, at the end, even when the message has one");
+        ok(line.rfind("data: ", 0) != 0, "NDJSON: no SSE prefix");
+        json body = json::parse(line, nullptr, false);
+        ok(body.is_object() && body.contains("error") && body["error"].is_string(),
+           "NDJSON: {\"error\": \"<text>\"}, the shape Ollama's client checks each line for");
+        if (body.is_object() && body.contains("error") && body["error"].is_string())
+            eq(body["error"].get<std::string>(), "NPU fault\nsecond line", "NDJSON: the message survives");
+    }
+
+    // what() can quote invalid UTF-8 (json::parse_error does). The error path must
+    // not throw on the thing it is reporting.
+    const std::string bad = std::string("parse error, last read: '") + '\xE5' + "'";
+    for (StreamWire w : {StreamWire::Sse, StreamWire::Ndjson}) {
+        const char* name = w == StreamWire::Sse ? "SSE" : "NDJSON";
+        bool threw = false;
+        std::vector<std::string> frames;
+        try {
+            frames = stream_error_frames(w, bad);
+        } catch (...) {
+            threw = true;
+        }
+        ok(!threw, std::string(name) + ": invalid UTF-8 in the message does not throw");
+        ok(!frames.empty() && frames[0].find("\xEF\xBF\xBD") != std::string::npos,
+           std::string(name) + ": ...it is replaced with U+FFFD");
+    }
+}
+
 int main(int argc, char** argv) {
     std::string list_path = argc > 1 ? argv[1] : "model_list.json";
     if (!fs::exists(list_path)) {
@@ -403,6 +528,7 @@ int main(int argc, char** argv) {
     test_preflight();
     test_resolve_task();
     test_task_policy();
+    test_stream_errors();
     test_is_chat_model(list_path);
 
     std::printf("\n%s (%d checks, %d failures)\n", failures ? "FAILED" : "PASS", checks, failures);

--- a/src/server/rest_handler.cpp
+++ b/src/server/rest_handler.cpp
@@ -20,6 +20,38 @@
 #include <random>
 #include "server.hpp"
 
+///@brief Report a handler's error on the transport the client is actually reading (#64)
+///@param stream what the handler's stream callback has already sent
+///@param wire the streaming format, used only once the stream is open
+///@param message the error text for an in-stream frame
+///@param body the error body to send when nothing is on the wire yet
+///@param send_response the non-streaming transport
+///@param sink the handler's own stream callback -- the one that updates `stream`
+///@note Which route applies is openai_compat::error_route(), unit-tested there.
+template <class FrameSink>
+static void send_error(const openai_compat::StreamState& stream,
+                       openai_compat::StreamWire wire,
+                       const std::string& message,
+                       const json& body,
+                       const std::function<void(const json&)>& send_response,
+                       FrameSink& sink) {
+    switch (openai_compat::error_route(stream)) {
+        case openai_compat::ErrorRoute::Body:
+            send_response(body);
+            return;
+        case openai_compat::ErrorRoute::Frame: {
+            const std::vector<std::string> frames = openai_compat::stream_error_frames(wire, message);
+            for (size_t i = 0; i < frames.size(); ++i) {
+                sink(frames[i], i + 1 == frames.size());
+            }
+            return;
+        }
+        case openai_compat::ErrorRoute::Unreportable:
+            header_print("OFLM", "Error after the stream ended; the client cannot be told: " + message);
+            return;
+    }
+}
+
 ///@brief Normalize messages by merging consecutive user messages (like Ollama does)
 ///@param messages the original messages
 ///@return normalized messages with consecutive user messages merged
@@ -724,6 +756,11 @@ void RestHandler::handle_generate(const json& request,
                                  std::function<void(const json&)> send_response,
                                  StreamResponseCallback send_streaming_response,
                                  std::shared_ptr<CancellationToken> cancellation_token) {
+    // Every frame goes through this, so an error knows whether the stream is open.
+    openai_compat::StreamState stream_state;
+    auto ndjson_stream_callback = [&send_streaming_response, &stream_state](const json& data, bool is_final) {
+        openai_compat::send_tracked(stream_state, is_final, [&] { send_streaming_response(data, is_final); });
+        };
     try {
         std::string prompt = request["prompt"];
         bool stream = request.value("stream", true);
@@ -748,7 +785,7 @@ void RestHandler::handle_generate(const json& request,
         if (stream) {
             // Streaming response using streaming_ostream
             auto total_start_time = time_utils::now();
-            streaming_ostream ostream(model, send_streaming_response, false);
+            streaming_ostream ostream(model, ndjson_stream_callback, false);
             uniformed_input.prompt = prompt;
             try {
                 bool success = auto_chat_engine->insert(meta_info, uniformed_input);
@@ -773,7 +810,9 @@ void RestHandler::handle_generate(const json& request,
                 auto_chat_engine->generate(meta_info, length_limit, ostream);
             } catch (const std::exception& e) {
                 json error_response = {{"error", e.what()}};
-                send_response(error_response);
+                // Tokens may already be on the wire, and then only a frame reaches the client.
+                send_error(stream_state, openai_compat::StreamWire::Ndjson, e.what(),
+                           error_response, send_response, ndjson_stream_callback);
                 this->auto_chat_engine->clear_context();
                 return;
             }
@@ -835,7 +874,8 @@ void RestHandler::handle_generate(const json& request,
         }
     } catch (const std::exception& e) {
         json error_response = {{"error", e.what()}};
-        send_response(error_response);
+        send_error(stream_state, openai_compat::StreamWire::Ndjson, e.what(),
+                   error_response, send_response, ndjson_stream_callback);
     }
 }
 
@@ -1328,6 +1368,13 @@ void RestHandler::handle_openai_chat_completion(const json& request,
                                                StreamResponseCallback send_streaming_response,
                                                std::shared_ptr<CancellationToken> cancellation_token) {
     static std::string model_used_for_last_message = "model-faker";
+    // Every frame goes through this, so an error knows whether the stream is open.
+    openai_compat::StreamState stream_state;
+    // Passes the pre-formatted SSE string directly
+    auto openai_stream_callback = [&send_streaming_response, &stream_state](const std::string& data, bool is_final) {
+        json data_json = data;
+        openai_compat::send_tracked(stream_state, is_final, [&] { send_streaming_response(data_json, is_final); });
+        };
     try {
         // Extract OpenAI-style parameters
         json current_messages = request["messages"];
@@ -1387,13 +1434,8 @@ void RestHandler::handle_openai_chat_completion(const json& request,
         meta_info.load_duration = (uint64_t)time_utils::duration_ns(load_start_time, load_end_time).first;
         meta_info.max_prefill_len = this->prefill_chunk_len;
         if (stream){
-            // Create a wrapper callback that passes the pre-formatted SSE string directly
             cancellation_token->reset();
             auto_chat_engine->reset_parser();
-            auto openai_stream_callback = [&send_streaming_response](const std::string& data, bool is_final) {
-                json data_json = data;
-                send_streaming_response(data_json, is_final);
-                };
             streaming_ostream_openai_chat ostream(model, auto_chat_engine.get(), openai_stream_callback);  // streaming in chat completion format
 
             header_print("OFLM", "Start prefill...");
@@ -1433,7 +1475,9 @@ void RestHandler::handle_openai_chat_completion(const json& request,
                 auto_chat_engine->generate(meta_info, length_limit, ostream, [&] { return cancellation_token->cancelled(); });
             } catch (const std::exception& e) {
                 json error_response = {{"error", e.what()}};
-                send_response(error_response);
+                // Tokens may already be on the wire, and then only a frame reaches the client.
+                send_error(stream_state, openai_compat::StreamWire::Sse, e.what(),
+                           error_response, send_response, openai_stream_callback);
                 this->auto_chat_engine->clear_context();
                 this->prompt_cache.reset();
                 return;
@@ -1529,7 +1573,8 @@ void RestHandler::handle_openai_chat_completion(const json& request,
                 {"code", 500}
             }}
         };
-        send_response(error_response);
+        send_error(stream_state, openai_compat::StreamWire::Sse, e.what(),
+                   error_response, send_response, openai_stream_callback);
     }
 }
 
@@ -1604,6 +1649,13 @@ void RestHandler::handle_openai_completion(const json& request,
     std::function<void(const json&)> send_response,
     StreamResponseCallback send_streaming_response,
     std::shared_ptr<CancellationToken> cancellation_token) {
+    // Every frame goes through this, so an error knows whether the stream is open.
+    openai_compat::StreamState stream_state;
+    // Passes the pre-formatted SSE string directly
+    auto openai_stream_callback = [&send_streaming_response, &stream_state](const std::string& data, bool is_final) {
+        json data_json = data;
+        openai_compat::send_tracked(stream_state, is_final, [&] { send_streaming_response(data_json, is_final); });
+        };
     try {
         // Extract OpenAI-style parameters
         std::string prompt = request["prompt"];
@@ -1633,11 +1685,6 @@ void RestHandler::handle_openai_completion(const json& request,
         header_print("OFLM", "Start generating...");
 
         if (stream) {
-            // Create a wrapper callback that passes the pre-formatted SSE string directly
-            auto openai_stream_callback = [&send_streaming_response](const std::string& data, bool is_final) {
-                json data_json = data;
-                send_streaming_response(data_json, is_final);
-                };
             streaming_ostream_openai ostream(model, openai_stream_callback);  // streaming in completion format
             uniformed_input.prompt = prompt;
             try {
@@ -1663,7 +1710,9 @@ void RestHandler::handle_openai_completion(const json& request,
                 auto_chat_engine->generate(meta_info, length_limit, ostream);
             } catch (const std::exception& e) {
                 json error_response = {{"error", e.what()}};
-                send_response(error_response);
+                // Tokens may already be on the wire, and then only a frame reaches the client.
+                send_error(stream_state, openai_compat::StreamWire::Sse, e.what(),
+                           error_response, send_response, openai_stream_callback);
                 this->auto_chat_engine->clear_context();
                 return;
             }
@@ -1736,6 +1785,7 @@ void RestHandler::handle_openai_completion(const json& request,
                 {"code", 500}
             }}
         };
-        send_response(error_response);
+        send_error(stream_state, openai_compat::StreamWire::Sse, e.what(),
+                   error_response, send_response, openai_stream_callback);
     }
 }


### PR DESCRIPTION
Fixes #64.

**What was wrong.** Once a streaming handler has sent a frame, `send_response()` can no longer reach the client. On hardware, with a fault injected into `generate()` after 5 tokens:
- a request that was not queued got nothing more and was never terminated. `/api/generate`, `/v1/chat/completions` and `/v1/completions` all hung until the client timed out.
- a queued request got a whole `HTTP/1.1 500` response written into its chunked body.

**The fix.** Each streaming callback records what it has already sent, and the catch blocks choose the transport from that:
- **Nothing sent yet:** the same error body and status as before.
- **Stream open:** the error goes in-stream, then the stream ends. SSE sends OpenAI's error object followed by `data: [DONE]`; NDJSON sends Ollama's `{"error": "..."}` line.
- **Stream already ended:** nothing is sent.

A final send that *throws* does not count as ended. Otherwise the error is dropped and the NPU queue never advances. That case was reproduced on hardware and has a unit test.

**Tested** on Granite 4.2 3B with the fault injection (not committed):
- All three endpoints end cleanly with the error in-stream, both queued and not queued.
- A fault before the first frame still answers 500 with a JSON body.
- Invalid UTF-8 in the message becomes U+FFFD.
- With no fault, the temperature-0 endpoints produce output identical to `main`, streaming and non-streaming.
- `openai_compat_test`: 120 checks pass, and `ctest` passes.

**Not in this PR.** `/api/chat` is untouched. Its streaming branch calls `insert()` twice and never calls `generate()`, so it has no mid-stream error to report. On `main` that request currently crashes the server, which is a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
